### PR TITLE
Add per-asset deep dive matrix to dev track

### DIFF
--- a/DEV_TRACK_EFFECTS_AND_DEMOS_PLAN.md
+++ b/DEV_TRACK_EFFECTS_AND_DEMOS_PLAN.md
@@ -1,0 +1,151 @@
+# Effects & Demos Dev Track Roadmap
+
+## Objectives
+- Build a repeatable process to analyze, document, enhance, and create Codex twin variations for every visual effect and interactive demo across the repository.
+- Work in small, iterative waves (2-3 items each) to maintain momentum while allowing deep dives into each asset.
+- Capture findings and updates in centralized documentation so future contributors can extend the visual systems efficiently.
+- Maintain a living inventory to guarantee coverage of **all** existing assets and prevent omissions in future planning cycles.
+
+## Asset Inventory & Clustering
+| Cluster | Effects | Demos |
+| --- | --- | --- |
+| **Holographic Baseline & Depth** | `effects/holographic-visualizer.html`, `effects/holographic-pulse-system.html` | `demos/holographic-particle-system-demo.html`, `demos/holographic-depth-layers-demo.html`, `demos/holographic-progress-indicators-demo.html`, `demos/holographic-parallax-systems-mega-demo.html`, `demos/active-holographic-systems-mega-demo.html`, `demos/active-holographic-systems-tabbed.html`, `demos/tech-layout-active-holographic-demo.html` |
+| **Orchestration & Narrative Systems** | `effects/multi-canvas-visualizer-system.html`, `effects/narrative-choreography-engine.html` | `demos/system-orchestration-engine-demo.html`, `demos/animated-grid-overlay-demo.html`, `demos/chaos-overlay-effects-demo.html`, `demos/millzmaleficarum-codex-demo.html` |
+| **Stateful Interaction Frameworks** | `effects/tabbed-visualizer-system.html` | `demos/state-control-dots-demo.html`, `demos/state-control-dots-mobile.html`, `demos/neoskeuomorphic-cards-demo.html`, `demos/neoskeuomorphic-cards-mobile.html` |
+| **CSS Visual Treatment Library** | `effects/enhanced-color-shift-contrast-system.html` | `demos/css-glassmorphism-demo.html`, `demos/css-glitch-effects-demo.html`, `demos/css-cyberpunk-ui-demo.html`, `demos/css-vaporwave-aesthetics-demo.html` |
+| **Hypercube & Moiré Engines** | `effects/mvep-moire-hypercube.html`, `effects/hypercube-core-framework.html`, `effects/hypercube-core-webgl-framework.html` | `demos/moire-hypercube-codex-demo.html`, `demos/hypercube-lattice-visualizer-demo.html`, `demos/polytopal-consciousness-shader-demo.html` |
+| **Advanced 4D Visualizers** | `effects/elegant-4d-flow-visualizer.html`, `effects/insane-hyperdimensional-matrix.html`, `effects/working-4d-hyperav.html` | — |
+| **Vib Codex Ecosystem** | `effects/vib34d-complete-system.html`, `effects/vib34d-complete-system-enhanced.html`, `effects/vib34d-advanced-card-bending-system.html` | `demos/vib34d-production-spectacular-demo.html`, `demos/vib34d-adaptive-cards-demo.html`, `demos/vib34d-editor-dashboard-demo.html`, `demos/vib34d-morphing-blog-demo.html`, `demos/vib3code-digital-magazine-demo.html`, `demos/vib3code-reactive-core-demo.html` |
+
+> _Inventory Stewardship_: Update this table whenever new assets ship or significant refactors occur. Mirror the inventory within `core_documentation/effects-and-demos-discovery.md` for traceability.
+
+## Methodology
+1. **Discovery & Baseline Capture**
+   - Open each effect/demo in a modern Chromium-based browser and record current behavior, compatibility notes, and dependencies.
+   - Inventory related assets (CSS, JS, media) and confirm they align with Codex naming conventions.
+   - Log initial observations in a shared worksheet (to be created in `core_documentation/` during Wave 1) and ensure inventory status reflects coverage.
+2. **Documentation Enhancement**
+   - Draft or expand Markdown briefs describing narrative intent, interaction flows, and integration requirements.
+   - Embed screenshots or GIFs when possible for quick visual diffing.
+   - Highlight any technical debt or UX concerns uncovered during discovery.
+3. **Experience Enhancements**
+   - Prioritize quick wins (performance tuning, accessibility, responsive fixes) before proposing larger redesigns.
+   - Validate improvements via local testing suites (`test-mobile-gallery-*`, custom smoke scripts) where applicable.
+4. **Codex Twin Creation**
+   - For each effect/demo, craft a “cousin” experience optimized for the alternate Codex (e.g., Millzmaleficarum vs. Vib3).
+   - Keep core narrative consistent while adjusting aesthetic language, theming, and interaction scaffolding.
+   - Document differences and shared components to streamline future syncs between Codex branches.
+5. **Review & Handoff**
+   - Package artifacts (before/after media, changelog summaries) for leadership review.
+   - File any follow-up tasks that emerge during QA.
+
+## Wave Plan
+| Wave | Focus Items | Primary Goals | Twin/Cousin Target |
+| --- | --- | --- | --- |
+| 1 | `effects/holographic-visualizer.html`, `effects/holographic-pulse-system.html`, `demos/holographic-particle-system-demo.html` | Establish discovery worksheet, capture holographic baselines, flag immediate accessibility fixes. | Craft Millzmaleficarum variants emphasizing ritualistic glow motifs. |
+| 2 | `demos/holographic-depth-layers-demo.html`, `demos/holographic-progress-indicators-demo.html`, `demos/holographic-parallax-systems-mega-demo.html` | Document depth/indicator UX, align motion easing, prep shared utility kit. | Deliver Vib3-inspired crystalline depth treatments. |
+| 3 | `demos/active-holographic-systems-mega-demo.html`, `demos/active-holographic-systems-tabbed.html`, `demos/tech-layout-active-holographic-demo.html` | Audit layout responsiveness, consolidate navigation scaffolding, benchmark performance. | Spin up Millz control-room twins with ceremonial panel styling. |
+| 4 | `effects/multi-canvas-visualizer-system.html`, `demos/system-orchestration-engine-demo.html`, `demos/animated-grid-overlay-demo.html` | Map orchestration logic, reduce layout thrash, document animation sequencing hooks. | Build Vib3 twin emphasizing minimal, data-forward overlays. |
+| 5 | `effects/tabbed-visualizer-system.html`, `demos/state-control-dots-demo.html`, `demos/state-control-dots-mobile.html` | Unify tab/state engines, ensure keyboard support, catalog reusable state tokens. | Create Millz versions featuring arcane state glyphs. |
+| 6 | `effects/narrative-choreography-engine.html`, `demos/millzmaleficarum-codex-demo.html`, `demos/chaos-overlay-effects-demo.html` | Capture narrative scripting model, align overlay layering rules, flag storytelling enhancements. | Author Vib3 reinterpretations with crystalline lore beats. |
+| 7 | `demos/css-glassmorphism-demo.html`, `demos/css-glitch-effects-demo.html`, `effects/enhanced-color-shift-contrast-system.html` | Normalize CSS effect tokens, document reusable mixins, test accessibility contrast. | Produce Millz CSS kit with occult gradients and shimmering edges. |
+| 8 | `demos/css-cyberpunk-ui-demo.html`, `demos/css-vaporwave-aesthetics-demo.html` | Evaluate aesthetic presets, create palette/tone matrices, ensure responsive typography scales. | Deliver Vib3 palette pack balancing neon and prismatic pastels. |
+| 9 | `effects/mvep-moire-hypercube.html`, `demos/moire-hypercube-codex-demo.html`, `demos/hypercube-lattice-visualizer-demo.html` | Compare Moiré implementations, optimize shader performance, document tuning parameters. | Release Millz twin focusing on ritual geometric resonance. |
+| 10 | `effects/hypercube-core-framework.html`, `effects/hypercube-core-webgl-framework.html`, `demos/polytopal-consciousness-shader-demo.html` | Audit framework APIs, ensure WebGL fallbacks, capture rendering pipeline diagrams. | Create Vib3 minimal twin highlighting clarity-first shader narratives. |
+| 11 | `effects/elegant-4d-flow-visualizer.html`, `effects/working-4d-hyperav.html`, `effects/insane-hyperdimensional-matrix.html` | Benchmark 4D pipelines, stabilize camera controls, outline extensibility hooks. | Build dual codex storyboards showing divergent dimensional aesthetics. |
+| 12 | `effects/vib34d-complete-system.html`, `effects/vib34d-complete-system-enhanced.html`, `demos/vib34d-production-spectacular-demo.html` | Consolidate Vib34d core modules, remove duplication, codify deployment checklist. | Deliver Millz production twin emphasizing arcane theater cues. |
+| 13 | `effects/vib34d-advanced-card-bending-system.html`, `demos/neoskeuomorphic-cards-demo.html`, `demos/neoskeuomorphic-cards-mobile.html` | Harmonize card interactions, ensure tactile feedback parity, document motion curves. | Ship Vib3 card suite highlighting crystalline skeuomorphism. |
+| 14 | `demos/vib34d-adaptive-cards-demo.html`, `demos/vib34d-editor-dashboard-demo.html`, `demos/vib34d-morphing-blog-demo.html` | Capture adaptive layout logic, align editor affordances, inventory dynamic content hooks. | Build Millz newsroom twin with parchment-and-glyph UI. |
+| 15 | `demos/vib3code-digital-magazine-demo.html`, `demos/vib3code-reactive-core-demo.html` | Detail reactive content streams, map data bindings, flag opportunities for progressive enhancement. | Deliver Vib3 → Millz crossover twin emphasizing shared storytelling modules. |
+
+## Asset Deep Dive Matrix
+| Asset | Primary Analysis Tasks | Documentation Deliverables | Enhancement Focus | Twin/Cousin Angle |
+| --- | --- | --- | --- | --- |
+| `effects/holographic-visualizer.html` | Capture shader, particle, and parallax configuration inputs; profile render loop timing. | Baseline diagram of shader stack, describe control sliders and default ranges. | Improve GPU throttling safeguards and responsive canvas sizing. | Millz version infuses occult sigil overlays with slower, pulsating bloom. |
+| `effects/holographic-pulse-system.html` | Record animation timing curves and audio-reactive hooks; audit accessibility for flashing. | Document pulse sequencing order and dependencies on shared CSS tokens. | Introduce prefers-reduced-motion handling and intensity throttles. | Vib3 twin offers crystalline pulse ribbons and prismatic flare gradients. |
+| `effects/multi-canvas-visualizer-system.html` | Map canvas layering orchestration and inter-canvas messaging. | Sequence diagram showing canvas update order and data flow. | Reduce redundant draws, add resize observers for canvas scaling. | Vib3 cousin leans into translucent glass panels with cool-spectrum highlights. |
+| `effects/narrative-choreography-engine.html` | Inspect narrative timeline JSON/JS config; track event dispatches. | Narrative scripting reference plus glossary of choreography primitives. | Add editor-friendly timeline controls and modular story blocks. | Vib3 reinterpretation emphasizes crystalline story fragments and linear progression. |
+| `effects/tabbed-visualizer-system.html` | Review tab switching logic, keyboard navigation, focus management. | Interaction brief with tab roles, ARIA expectations, and state diagram. | Harden keyboard/ARIA coverage and smooth inertia transitions. | Millz twin swaps neon tabs for rune-inscribed plates with subtle glow trails. |
+| `effects/enhanced-color-shift-contrast-system.html` | Extract CSS custom properties, detect dynamic filter chains. | Token catalog for hues/contrast states plus usage playbook. | Build palette generator controls and ensure WCAG contrast for presets. | Vib3 cousin introduces pastel-to-iridescent gradient morphs. |
+| `effects/mvep-moire-hypercube.html` | Trace vertex/fragment shaders and Moiré interference computations. | Annotated shader walkthrough with parameter matrix. | Optimize uniforms for mobile GPUs and cap frame rates. | Millz variant accentuates ritual lattice etchings and smoky overlays. |
+| `effects/hypercube-core-framework.html` | Document API surface, initialization lifecycle, shared math utilities. | API reference plus module dependency graph. | Modularize math helpers, add TypeScript typings scaffold. | Vib3 twin highlights minimalist crystalline frameworks with blue-white palette. |
+| `effects/hypercube-core-webgl-framework.html` | Verify WebGL context setup, fallback paths, extension usage. | Troubleshooting appendix covering context loss recovery steps. | Implement context restoration hooks and feature detection. | Millz cousin adds volumetric fog and glyph-etched nodes. |
+| `effects/elegant-4d-flow-visualizer.html` | Profile 4D projection math, inspect control UI binding. | Flow field explainer and user control cheat-sheet. | Add pause/scrub controls and export snapshots. | Vib3 version infuses crystalline ribbons with refractive gleam. |
+| `effects/insane-hyperdimensional-matrix.html` | Audit transformation matrices, camera controls, and shader combos. | Technical deep dive on dimension toggles and camera pathing. | Smooth camera easing and add progressive detail toggles. | Millz twin leans into arcane cube constellations with ember glows. |
+| `effects/working-4d-hyperav.html` | Inspect audio-visual sync logic and analyser node usage. | Audio-reactive mapping chart and recommended audio specs. | Upgrade analyser smoothing and add audio input selector. | Vib3 cousin uses crystalline prisms that refract beats into color shards. |
+| `effects/vib34d-complete-system.html` | Catalogue component registry, service orchestration, and styling tokens. | Comprehensive architecture map with module cross-links. | Reduce bundle size, share more tokens with enhanced system. | Millz twin transforms panels into ritual theater wings. |
+| `effects/vib34d-complete-system-enhanced.html` | Compare with base system, flag deltas, ensure documentation parity. | Delta log enumerating enhanced modules and feature flags. | Merge duplicated logic back into shared libs; tighten performance budgets. | Vib3 cousin positions enhancements as crystalline upgrades with shimmering overlays. |
+| `effects/vib34d-advanced-card-bending-system.html` | Review 3D transforms, pointer tracking, and physics easing. | Interaction storyboard for card bending arcs and triggers. | Add spring physics controls and pointer device parity. | Millz variant swaps card art for sigil-laden parchment with ember trails. |
+| `demos/holographic-particle-system-demo.html` | Confirm emitter presets, particle lifespans, and UI toggles. | Particle preset catalog with parameter definitions. | Optimize emitter pooling, add preset save/load workflow. | Millz twin injects candle-smoke particles and runic bursts. |
+| `demos/holographic-depth-layers-demo.html` | Trace z-layer ordering, parallax offsets, and motion triggers. | Layer stack diagrams and recommended depth configs. | Improve depth map authoring tools, add VRAM budgeting tips. | Vib3 cousin showcases crystalline strata with refractive shards. |
+| `demos/holographic-progress-indicators-demo.html` | Audit progress component variants and animation pacing. | Component gallery with usage guidance and accessibility checklist. | Ensure screen-reader announcements and color contrast compliance. | Millz version applies ritual glyph progress etchings. |
+| `demos/holographic-parallax-systems-mega-demo.html` | Map parallax triggers, scroll interactions, and asset loading. | Scroll choreography guide plus asset performance ledger. | Introduce lazy-loading for heavy assets and reduce scroll jank. | Vib3 twin trades neon glow for polished glass parallax layers. |
+| `demos/active-holographic-systems-mega-demo.html` | Document system layout, module interplay, and navigation. | Mega-demo handbook capturing module responsibilities. | Componentize repeating patterns and add route-aware states. | Millz twin conveys ritual control panels with ember-lit frames. |
+| `demos/active-holographic-systems-tabbed.html` | Inspect tab-state integration, cross-module comms, and analytics hooks. | Tab matrix describing module combos and activation paths. | Add analytics opt-in toggles and keyboard parity fixes. | Vib3 cousin emphasizes crystalline tab separators and color-cycled focus rings. |
+| `demos/tech-layout-active-holographic-demo.html` | Evaluate layout grid, responsive breakpoints, and typography scale. | Layout spec sheet with breakpoint diagrams. | Improve clamp-based typography and reduce DOM nesting. | Millz twin uses serif rune typography with parchment textures. |
+| `demos/system-orchestration-engine-demo.html` | Trace orchestration engine APIs and scenario scripts. | Orchestration scenario playbook referencing engine hooks. | Harden error handling and expose scenario builder UI. | Vib3 cousin leans into cool-toned crystalline conductor desk. |
+| `demos/animated-grid-overlay-demo.html` | Inspect overlay animation cadence and shader overlays. | Frame-by-frame overlay storyboard and CSS token mapping. | Optimize animation keyframes and GPU compositing hints. | Millz variant injects glowing gridlines with ember-lit nodes. |
+| `demos/chaos-overlay-effects-demo.html` | Analyze chaos parameters, randomness seeds, and event triggers. | Chaos parameter glossary and reproducibility checklist. | Add deterministic seed options and debug HUD. | Vib3 cousin reframes chaos as prismatic burst sequences. |
+| `demos/millzmaleficarum-codex-demo.html` | Review codex narrative script, interactive beats, and theming tokens. | Narrative doc with lore timelines and interaction map. | Tighten performance for heavy glow filters, add mobile fallback. | Vib3 twin maintains lore while applying crystalline UI tokens. |
+| `demos/state-control-dots-demo.html` | Inspect state management, transitions, and pointer events. | State machine diagram and event catalog. | Add pointer capture fallback and accessible status messaging. | Millz cousin introduces rune dots with ember pulses. |
+| `demos/state-control-dots-mobile.html` | Validate touch gestures, orientation handling, and low-power performance. | Mobile testing checklist and device compatibility matrix. | Implement motion scaling for low-end devices and adjust hit targets. | Vib3 twin focuses on glassy orbs with gentle color breathing. |
+| `demos/neoskeuomorphic-cards-demo.html` | Audit card layout, depth shadows, and hover states. | Component design brief covering layer tokens and states. | Improve responsive stacking and reduce heavy box-shadow costs. | Vib3 cousin trades warm leather for crystalline acrylic shells. |
+| `demos/neoskeuomorphic-cards-mobile.html` | Test mobile card interactions, thumb reach zones, and load times. | Mobile-specific card usage guidelines. | Add lazy-loading for card assets and lighten gradients. | Millz twin centers parchment textures with embossed glyph icons. |
+| `demos/css-glassmorphism-demo.html` | Catalog blur levels, color tokens, and background layering. | Glassmorphism token index and recommended contexts. | Add adaptive blur for low-powered devices and optional noise overlays. | Millz cousin uses frost-on-obsidian panes with amber glow. |
+| `demos/css-glitch-effects-demo.html` | Identify glitch animation sequences, filter effects, and timing. | Glitch technique compendium with sample code. | Reduce CPU-heavy filters and add reduced-motion safe mode. | Vib3 twin renders crystalline glitch shards with high-chroma bursts. |
+| `demos/css-cyberpunk-ui-demo.html` | Examine UI component variants, neon accents, and grid layouts. | UI kit overview with component taxonomy. | Improve component theming toggles and add dark/light duality. | Millz twin reimagines as arcane-tech interface with ember runes. |
+| `demos/css-vaporwave-aesthetics-demo.html` | Review gradient systems, typography, and icon usage. | Vaporwave style guide with palette table and font stack notes. | Add responsive typography tokens and alternative palettes for accessibility. | Vib3 cousin refracts palette toward crystalline pastels and holographic chrome. |
+| `demos/moire-hypercube-codex-demo.html` | Profile shader complexity, interactive controls, and camera drift. | Moiré hypercube controller reference. | Add camera reset button and mobile-safe defaults. | Millz twin overlays ancient glyph alignments on the hypercube faces. |
+| `demos/hypercube-lattice-visualizer-demo.html` | Audit lattice generation logic, data inputs, and animation speed. | Lattice generation spec with dataset requirements. | Introduce step-based speed controls and performance metrics overlay. | Vib3 cousin employs faceted glass nodes with refracted light beams. |
+| `demos/polytopal-consciousness-shader-demo.html` | Inspect shader pipeline, uniform controls, and color grading. | Shader field guide and parameter cheat sheet. | Add preset library and GPU performance profiling hooks. | Millz twin darkens palette with ember-lit polytopes and swirling mist. |
+| `demos/vib34d-production-spectacular-demo.html` | Map production flow, stage transitions, and UI overlays. | Production storyboard and asset manifest. | Optimize scene transitions and prefetch heavy assets. | Millz cousin frames production as ritual theater with animated curtains. |
+| `demos/vib34d-adaptive-cards-demo.html` | Evaluate adaptive layout logic and data binding. | Adaptive card schema docs and responsive rules. | Add dynamic content slotting and offline caching guidance. | Vib3 twin features crystalline card shells with gradient pulses. |
+| `demos/vib34d-editor-dashboard-demo.html` | Inspect editor modules, data stores, and collaborative hooks. | Editor module catalog and data flow diagram. | Introduce autosave, undo stack, and collaborative presence indicators. | Millz twin reskins dashboard with parchment panels and rune toggles. |
+| `demos/vib34d-morphing-blog-demo.html` | Trace morphing layout engine, article templates, and transitions. | Morphing layout cookbook plus content authoring checklist. | Optimize DOM diffing, add content preview instrumentation. | Vib3 cousin trades warm parchment for crystalline blog frames. |
+| `demos/vib3code-digital-magazine-demo.html` | Review magazine navigation, lazy-loading, and animation rhythm. | Magazine navigation guide with asset loading map. | Add offline-ready caching and adjustable animation speed. | Millz twin introduces ritual codex spreads with parchment textures. |
+| `demos/vib3code-reactive-core-demo.html` | Inspect reactive data flows, event buses, and visualization updates. | Reactive core reference with pub/sub contract. | Improve diagnostics tooling, add event replay panel. | Vib3 → Millz crossover highlights shared modules with dual theming toggles. |
+
+## Wave Execution Playbooks
+| Wave | Discovery Focus | Documentation Tasks | Enhancement Experiments | Twin/Cousin Production |
+| --- | --- | --- | --- | --- |
+| 1 | Capture holographic baselines, confirm shared CSS/JS dependencies, measure FPS on desktop and mobile. | Draft discovery worksheet structure and holographic asset briefs. | Prototype responsive canvas scaling and reduced-motion toggles. | Build Millz pulse/visualizer cousins with glyph overlays and slower bloom. |
+| 2 | Stress-test depth layers and progress indicators across scroll contexts; gather performance metrics. | Extend briefs with depth-layer diagrams and indicator accessibility logs. | Tune parallax easing and lighten indicator gradients for clarity. | Craft Vib3 crystalline depth variants using refractive palette. |
+| 3 | Map mega-demo module interplay and navigation heuristics; profile load order. | Produce mega-demo handbook summarizing modules, dependencies, and analytics hooks. | Modularize shared navigation and throttle animation loops. | Design Millz control-room overlays with ember-lit toggles. |
+| 4 | Analyze orchestration engine message bus and grid overlay animation timings. | Write orchestration API quickstart plus overlay storyboard. | Reduce layout thrash via CSS grid refinements and requestAnimationFrame batching. | Compose Vib3 minimalist overlay twin with cool-toned gradients. |
+| 5 | Validate tab/state management on desktop + mobile; run accessibility audits. | Deliver state machine diagrams and ARIA coverage checklist. | Add pointer capture fallback, focus ring visibility, and animation dampening. | Author Millz rune-tab prototypes with ceremonial glyph glow. |
+| 6 | Review narrative scripting assets and chaos overlay randomness; ensure reproducible seeds. | Document lore timelines, chaos parameter glossary, and storytelling heuristics. | Implement deterministic seed injection and overlay layering guardrails. | Shape Vib3 lore reinterpretations with crystalline story beats. |
+| 7 | Collect CSS token inventory for glass/glitch demos; evaluate device compatibility. | Publish CSS token indexes with recommended usage and code samples. | Add reduced-motion variants and lighten heavy filter stacks. | Produce Millz-themed CSS bundles with obsidian glass and amber light leaks. |
+| 8 | Examine aesthetic preset toggles and typography scales under varied resolutions. | Create palette/typography matrices and style guide updates. | Add clamp-based typography utilities and preset export tool. | Deliver Vib3 palette pack balancing neon and pastel prisms. |
+| 9 | Profile Moiré hypercube shader parameters, camera controls, and mobile fallbacks. | Write shader walkthroughs and camera control cheat-sheets. | Introduce camera reset, framerate caps, and device capability detection. | Build Millz ritual hypercube variant with glyph-laced faces. |
+| 10 | Document hypercube framework APIs and WebGL fallback strategies. | Produce API reference and troubleshooting appendix. | Add context loss recovery, modular math utilities, and TypeScript stubs. | Craft Vib3 minimalist twin with luminous crystalline nodes. |
+| 11 | Analyze 4D visualization controls, audio sync, and complexity toggles. | Publish 4D visualization guides with control maps and audio specs. | Implement adjustable complexity sliders and screenshot exporter. | Develop dual codex storyboard comparing dimensional aesthetics. |
+| 12 | Evaluate Vib34d system deltas and production pipeline readiness. | Author architecture comparison and deployment checklist. | De-duplicate modules, reduce bundle size, and align tokens. | Produce Millz production twin with ritual staging cues. |
+| 13 | Inspect neoskeuomorphic card interactions across devices. | Produce card interaction brief, mobile guidelines, and motion curves doc. | Introduce pointer parity, lighten gradients, and lazy-load heavy art. | Deliver Vib3 crystalline skeuomorphic suite with refractive edges. |
+| 14 | Audit adaptive cards, editor dashboard, and morphing blog pipelines. | Write adaptive schema docs, editor module catalog, and morphing layout cookbook. | Add offline caching, autosave, and DOM diff profiling. | Skin Millz newsroom twin with parchment textures and rune toggles. |
+| 15 | Trace reactive core event flows and magazine navigation experiences. | Document pub/sub contract, data binding map, and magazine asset manifest. | Add event replay panel, offline-ready caching, and adjustable animation pacing. | Launch crossover theming toggle enabling Vib3 ↔ Millz transitions. |
+
+## Supporting Tasks
+- **Discovery Worksheet**: Launch `core_documentation/effects-and-demos-discovery.md` during Wave 1 to log observations, performance metrics, and QA notes. Include inventory checkboxes to ensure no asset is skipped.
+- **Screenshot & Media Library**: Store before/after captures under `gallery/` subfolders with consistent naming (e.g., `holographic-visualizer-before.png`).
+- **Testing Pipeline**: Extend existing Puppeteer scripts (see `test-mobile-gallery-*`) to include automated sanity checks for selected demos. Capture wave-by-wave regression baselines.
+- **Codex Theming Tokens**: Compile shared design tokens for both codex variants (color palettes, typography scales, particle configs) to expedite twin creation.
+- **Status Dashboards**: Publish a lightweight kanban in `core_documentation/` referencing each wave so stakeholders can track coverage and blockers.
+
+## Milestones & Checkpoints
+- **Week 1**: Complete Waves 1-3 analysis, publish discovery worksheet, secure stakeholder sign-off on twin theming guidelines.
+- **Week 2**: Execute Waves 4-6, integrate first codex twin prototypes, run regression tests on holographic/orchestration assets.
+- **Week 3**: Deliver Waves 7-9, finalize CSS library documentation, validate shader optimization backlog.
+- **Week 4**: Finish Waves 10-12, host internal review of Vib34d system improvements, prep cross-codex rollout checklist.
+- **Week 5**: Wrap Waves 13-15, consolidate learnings into `VISUAL_CODEX_ENHANCEMENT_TASKS.md`, and propose next-phase initiatives.
+
+## Risks & Mitigations
+- **Scope Creep**: Limit each wave to documented goals; funnel new ideas into backlog for future waves.
+- **Twin Divergence**: Maintain shared component library with codex-specific overrides to prevent code drift.
+- **Testing Debt**: Automate regression checks early to avoid manual QA bottlenecks.
+- **Inventory Drift**: Review the asset table weekly so new effects/demos are captured before planning gaps emerge.
+
+## Next Steps
+1. Kick off Wave 1 discovery, generate baseline screenshots, and populate the shared worksheet with inventory status toggles.
+2. Draft twin design language briefs for Millzmaleficarum and Vib3 codices, aligning color/typography/token matrices.
+3. Schedule weekly checkpoints to review progress, surface blockers, and reprioritize waves as needed.
+4. Stand up the kanban/status tracker and link it to the discovery worksheet for live coverage monitoring.


### PR DESCRIPTION
## Summary
- extend the effects and demos roadmap with a comprehensive deep dive matrix for every asset
- add wave execution playbooks that detail discovery, documentation, enhancement, and twin deliverables per wave

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e56b2ccb5883299c31560789b736ff