### PR TITLE
Add session preferences and keyboard shortcuts to codex gallery

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,24 @@ An advanced interactive gallery showcasing 39 unique visual effects and style de
 - **39 Visual Effects**: Holographic systems, 4D visualizers, particle effects, CSS animations
 - **Lazy Loading**: Efficient iframe loading prevents WebGL context overload
 - **Interactive Previews**: Mouse, scroll, and click interactions
+- **Dataset Switcher**: Floating control for instant swapping between gallery datasets without leaving the page
+- **Control Deck Analytics**: Inline insights panel with tag filters, section metrics, and curated callouts for each dataset
+- **Instant Search**: New codex search overlays surface matching sections, wafers, and demos as you type (with keyboard-accessible clear control)
+- **Deep Link Sharing**: Copyable section and card permalinks with history-aware URLs for quick collaboration
+- **Session Memory**: Optional per-dataset preferences remember your last section, spotlight, tag focus, and search state when you return
+- **Keyboard Navigation**: Arrow keys, bracket cycling, number spotlights, `/` to focus search, and `Shift + ?` to open an in-app shortcut guide with `Alt + Shift + D` control deck toggles
+- **Accessibility Aware**: Honors `prefers-reduced-motion` and falls back to CSS backgrounds when WebGL is unavailable
 - **Responsive Design**: Mobile-optimized with VaporWave aesthetics
 
 ## 🚀 Quick Start
 
 ### View on GitHub Pages
 Visit: https://[your-username].github.io/visual-codex/
+
+### Available Systems
+- **Proper 4D System** (`gallery-proper-system.html?gallery=proper`): Original curated polytopal showcase with WebGL backgrounds and reactive crystal wafers.
+- **Aurora Twin System** (`gallery-aurora-system.html?gallery=twin`): Alternate curation featuring Aurora-inspired palettes, mobile-first groupings, and tooling-oriented heavy entries.
+- You can also stay on either shell and use the in-page dataset switcher to jump between modes; query parameters (`?gallery=...`) keep the view in sync.
 
 ### Local Development
 ```bash

--- a/css/gallery-proper-system.css
+++ b/css/gallery-proper-system.css
@@ -1,0 +1,1948 @@
+@import url('https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700;900&display=swap');
+
+body.theme-prime,
+:root {
+    --silicon-green: #0d2818;
+    --crystal-teal: #00ffaa;
+    --accent-red: #ff004d;
+    --neon-cyan: #00ffff;
+    --neon-magenta: #ff00ff;
+    --neon-yellow: #ffff00;
+    --electric-blue: #0080ff;
+}
+
+body.theme-aurora {
+    --silicon-green: #071a2c;
+    --crystal-teal: #7efbff;
+    --accent-red: #ff6ac1;
+    --neon-cyan: #66fff9;
+    --neon-magenta: #d57bff;
+    --neon-yellow: #f9ff9a;
+    --electric-blue: #4a9dff;
+}
+
+body.gallery-shell {
+    background: #000;
+    color: var(--crystal-teal);
+    font-family: 'Orbitron', 'Courier New', monospace;
+    overflow-x: hidden;
+    cursor: crosshair;
+    height: 100vh;
+    overflow-y: hidden;
+    perspective: 2000px;
+}
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            background: #000;
+            color: var(--crystal-teal);
+            font-family: 'Orbitron', 'Courier New', monospace;
+        }
+
+.dataset-switcher {
+    position: fixed;
+    top: 2rem;
+    right: 2rem;
+    z-index: 20;
+    display: flex;
+    gap: 0.75rem;
+    padding: 0.75rem 1rem;
+    background: rgba(0, 0, 0, 0.55);
+    border: 1px solid rgba(0, 255, 255, 0.2);
+    border-radius: 999px;
+    backdrop-filter: blur(12px);
+    box-shadow: 0 0 35px rgba(0, 255, 255, 0.25);
+}
+
+.dataset-switcher a {
+    color: var(--neon-cyan);
+    text-decoration: none;
+    font-size: 0.75rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    padding: 0.4rem 0.9rem;
+    border-radius: 999px;
+    border: 1px solid transparent;
+    transition: color 0.3s ease, border-color 0.3s ease, background 0.3s ease;
+}
+
+.dataset-switcher a:hover {
+    border-color: rgba(0, 255, 255, 0.55);
+    background: rgba(0, 255, 255, 0.12);
+}
+
+.dataset-switcher a.is-active {
+    border-color: rgba(0, 255, 255, 0.9);
+    background: rgba(0, 255, 255, 0.18);
+    color: #001b1c;
+    box-shadow: 0 0 20px rgba(0, 255, 255, 0.4);
+}
+
+.dataset-switcher a.is-disabled {
+    opacity: 0.4;
+    pointer-events: none;
+}
+
+.control-deck {
+    position: fixed;
+    top: 6.75rem;
+    right: 2rem;
+    z-index: 18;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 0.75rem;
+    max-width: calc(100vw - 2rem);
+}
+
+.control-deck-toggle {
+    background: rgba(0, 0, 0, 0.6);
+    border: 1px solid rgba(0, 255, 255, 0.35);
+    color: var(--neon-cyan);
+    text-transform: uppercase;
+    letter-spacing: 0.16em;
+    font-size: 0.65rem;
+    padding: 0.55rem 0.9rem;
+    border-radius: 999px;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    cursor: pointer;
+    transition: transform 0.25s ease, border-color 0.25s ease, background 0.25s ease, color 0.25s ease;
+    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.45);
+}
+
+.control-deck-toggle:hover,
+.control-deck.open .control-deck-toggle {
+    transform: translateY(-2px);
+    border-color: rgba(0, 255, 255, 0.65);
+    background: rgba(0, 0, 0, 0.75);
+    color: #001b1c;
+}
+
+.control-deck-toggle-label {
+    font-weight: 700;
+}
+
+.control-deck-toggle-status {
+    font-size: 0.55rem;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    color: rgba(0, 255, 255, 0.65);
+}
+
+.control-deck-panel {
+    width: min(360px, calc(100vw - 2.25rem));
+    background: rgba(0, 0, 0, 0.85);
+    border: 1px solid rgba(0, 255, 255, 0.25);
+    border-radius: 18px;
+    padding: 1.1rem 1.25rem 1.35rem;
+    box-shadow:
+        0 45px 90px rgba(0, 0, 0, 0.6),
+        inset 0 0 0 1px rgba(0, 255, 255, 0.08);
+    backdrop-filter: blur(16px);
+    transform: translateY(-12px);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.35s ease, transform 0.35s ease;
+}
+
+.control-deck.open .control-deck-panel {
+    opacity: 1;
+    transform: translateY(0);
+    pointer-events: auto;
+}
+
+.control-deck-header {
+    margin-bottom: 0.85rem;
+}
+
+.control-deck-title {
+    font-size: 1.0rem;
+    letter-spacing: 0.28em;
+    text-transform: uppercase;
+    color: var(--neon-cyan);
+    font-weight: 700;
+}
+
+.control-deck-subtitle {
+    margin-top: 0.35rem;
+    font-size: 0.7rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: rgba(0, 255, 255, 0.6);
+}
+
+.control-deck-summary {
+    font-size: 0.72rem;
+    line-height: 1.6;
+    color: rgba(0, 255, 255, 0.72);
+    margin-bottom: 1.1rem;
+}
+
+.control-deck-search {
+    margin-bottom: 1rem;
+    padding: 0.85rem 0.9rem 0.95rem;
+    border-radius: 12px;
+    background: rgba(0, 255, 255, 0.05);
+    border: 1px solid rgba(0, 255, 255, 0.12);
+    box-shadow: inset 0 0 18px rgba(0, 255, 255, 0.08);
+}
+
+.control-deck-search-label {
+    display: block;
+    font-size: 0.6rem;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: rgba(0, 255, 255, 0.65);
+    margin-bottom: 0.45rem;
+}
+
+.control-deck-search-field {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+}
+
+.control-deck-search-field input[type="search"] {
+    width: 100%;
+    padding: 0.55rem 0.8rem;
+    border-radius: 999px;
+    border: 1px solid rgba(0, 255, 255, 0.25);
+    background: rgba(0, 0, 0, 0.6);
+    color: var(--neon-cyan);
+    font-size: 0.72rem;
+    letter-spacing: 0.05em;
+    transition: border-color 0.25s ease, box-shadow 0.25s ease;
+}
+
+.control-deck-search-field input[type="search"]::placeholder {
+    color: rgba(0, 255, 255, 0.35);
+}
+
+.control-deck-search-field input[type="search"]:focus {
+    outline: none;
+    border-color: rgba(0, 255, 255, 0.55);
+    box-shadow: 0 0 0 3px rgba(0, 255, 255, 0.15);
+}
+
+.control-deck-search-clear {
+    width: 2rem;
+    height: 2rem;
+    border-radius: 50%;
+    border: 1px solid rgba(0, 255, 255, 0.25);
+    background: rgba(0, 0, 0, 0.55);
+    color: rgba(0, 255, 255, 0.75);
+    font-size: 1rem;
+    line-height: 1;
+    cursor: pointer;
+    transition: border-color 0.25s ease, color 0.25s ease, background 0.25s ease;
+}
+
+.control-deck-search-clear:hover {
+    border-color: rgba(0, 255, 255, 0.6);
+    color: rgba(255, 0, 255, 0.8);
+    background: rgba(0, 0, 0, 0.75);
+}
+
+.control-deck-search-clear:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+    pointer-events: none;
+}
+
+.control-deck-search-help {
+    margin-top: 0.45rem;
+    font-size: 0.58rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: rgba(0, 255, 255, 0.45);
+}
+
+.control-deck-search-results {
+    margin-top: 0.7rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.55rem;
+    max-height: 220px;
+    overflow-y: auto;
+    padding-right: 0.35rem;
+}
+
+.control-deck-search-results::-webkit-scrollbar {
+    width: 6px;
+}
+
+.control-deck-search-results::-webkit-scrollbar-thumb {
+    background: rgba(0, 255, 255, 0.25);
+    border-radius: 999px;
+}
+
+.control-deck-search-results.empty {
+    gap: 0;
+}
+
+.control-deck-search-placeholder {
+    font-size: 0.65rem;
+    line-height: 1.5;
+    color: rgba(0, 255, 255, 0.45);
+}
+
+.control-deck-search-item {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    padding: 0.55rem 0.6rem 0.6rem;
+    border-radius: 10px;
+    border: 1px solid rgba(0, 255, 255, 0.12);
+    background: rgba(0, 255, 255, 0.04);
+    transition: border-color 0.25s ease, background 0.25s ease;
+}
+
+.control-deck-search-item:hover {
+    border-color: rgba(0, 255, 255, 0.4);
+    background: rgba(0, 255, 255, 0.08);
+}
+
+.control-deck-search-item a {
+    color: var(--neon-cyan);
+    text-decoration: none;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+}
+
+.control-deck-search-item a:hover {
+    color: rgba(255, 0, 255, 0.85);
+}
+
+.control-deck-search-item .control-deck-search-meta {
+    font-size: 0.58rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: rgba(0, 255, 255, 0.55);
+}
+
+.control-deck-search-item .control-deck-search-tags {
+    font-size: 0.58rem;
+    letter-spacing: 0.06em;
+    color: rgba(0, 255, 255, 0.5);
+}
+
+.control-deck-search-item.current-section {
+    border-color: rgba(255, 0, 255, 0.35);
+    box-shadow: 0 0 15px rgba(255, 0, 255, 0.15);
+}
+
+.control-deck-search-more {
+    font-size: 0.6rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: rgba(0, 255, 255, 0.5);
+    margin-top: 0.2rem;
+}
+
+.control-deck-share {
+    margin-bottom: 1rem;
+    padding: 0.85rem 0.9rem 0.95rem;
+    border-radius: 12px;
+    background: rgba(0, 255, 255, 0.05);
+    border: 1px solid rgba(0, 255, 255, 0.12);
+    box-shadow: inset 0 0 18px rgba(0, 255, 255, 0.08);
+}
+
+.control-deck-share-title {
+    font-size: 0.6rem;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: rgba(0, 255, 255, 0.65);
+    margin-bottom: 0.6rem;
+}
+
+.control-deck-share-actions {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.55rem;
+}
+
+.control-deck-share-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.55rem 0.65rem;
+    border-radius: 10px;
+    border: 1px solid rgba(0, 255, 255, 0.25);
+    background: rgba(0, 0, 0, 0.55);
+    color: rgba(0, 255, 255, 0.85);
+    font-size: 0.68rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    cursor: pointer;
+    transition: border-color 0.25s ease, box-shadow 0.25s ease, transform 0.2s ease, color 0.25s ease;
+}
+
+.control-deck-share-button:hover,
+.control-deck-share-button:focus {
+    border-color: rgba(0, 255, 255, 0.6);
+    color: rgba(255, 0, 255, 0.85);
+    box-shadow: 0 0 12px rgba(0, 255, 255, 0.25);
+    transform: translateY(-1px);
+    outline: 2px solid rgba(0, 255, 255, 0.6);
+    outline-offset: 2px;
+}
+
+.control-deck-share-button:active {
+    transform: translateY(1px);
+}
+
+.control-deck-share-button:disabled,
+.control-deck-share-button[aria-disabled="true"] {
+    opacity: 0.45;
+    cursor: not-allowed;
+    border-color: rgba(0, 255, 255, 0.15);
+    color: rgba(0, 255, 255, 0.4);
+    box-shadow: none;
+    transform: none;
+}
+
+.control-deck-share-status {
+    margin-top: 0.65rem;
+    min-height: 1.2em;
+    font-size: 0.64rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: rgba(0, 255, 255, 0.65);
+}
+
+.control-deck-share-status.error {
+    color: rgba(255, 80, 120, 0.85);
+}
+
+.control-deck-preferences {
+    margin-bottom: 1rem;
+    padding: 0.9rem 1rem 1rem;
+    border-radius: 14px;
+    background: linear-gradient(135deg, rgba(0, 255, 255, 0.06) 0%, rgba(255, 0, 255, 0.04) 100%);
+    border: 1px solid rgba(0, 255, 255, 0.12);
+    box-shadow: inset 0 0 18px rgba(0, 255, 255, 0.08);
+}
+
+.control-deck-preferences-header {
+    margin-bottom: 0.75rem;
+}
+
+.control-deck-preferences-title {
+    font-size: 0.62rem;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    color: rgba(0, 255, 255, 0.75);
+}
+
+.control-deck-preferences-subtitle {
+    margin-top: 0.4rem;
+    font-size: 0.68rem;
+    line-height: 1.4;
+    color: rgba(255, 255, 255, 0.62);
+}
+
+.control-deck-preference-list {
+    display: grid;
+    gap: 0.55rem;
+    margin-bottom: 0.85rem;
+}
+
+.control-deck-preference {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 0.65rem;
+    align-items: start;
+    padding: 0.55rem 0.65rem;
+    border-radius: 10px;
+    background: rgba(0, 0, 0, 0.45);
+    border: 1px solid rgba(0, 255, 255, 0.12);
+    cursor: pointer;
+    transition: border-color 0.25s ease, box-shadow 0.25s ease;
+}
+
+.control-deck-preference:hover,
+.control-deck-preference:focus-within {
+    border-color: rgba(0, 255, 255, 0.35);
+    box-shadow: 0 0 16px rgba(0, 255, 255, 0.18);
+}
+
+.control-deck-preference input[type="checkbox"] {
+    width: 1.1rem;
+    height: 1.1rem;
+    margin: 0.2rem 0 0;
+    border-radius: 6px;
+    border: 1px solid rgba(0, 255, 255, 0.35);
+    background: rgba(0, 0, 0, 0.6);
+    appearance: none;
+    position: relative;
+    cursor: pointer;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.control-deck-preference input[type="checkbox"]:checked {
+    background: rgba(0, 255, 255, 0.25);
+    box-shadow: 0 0 10px rgba(0, 255, 255, 0.35);
+}
+
+.control-deck-preference input[type="checkbox"]:checked::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: 6px;
+    background: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 10"%3E%3Cpath fill="%2300FFFF" d="M4.6 7.8L1.4 4.6 0 6l4.6 4 7-7L10.2 2z"/%3E%3C/svg%3E') center/12px 10px no-repeat;
+}
+
+.control-deck-preference input[type="checkbox"]:focus-visible {
+    outline: 2px solid rgba(255, 0, 255, 0.45);
+    outline-offset: 2px;
+}
+
+.control-deck-preference-body {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.control-deck-preference-name {
+    font-size: 0.7rem;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: rgba(0, 255, 255, 0.8);
+}
+
+.control-deck-preference-description {
+    font-size: 0.66rem;
+    line-height: 1.45;
+    color: rgba(255, 255, 255, 0.62);
+}
+
+.control-deck-help-button {
+    width: 100%;
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+    padding: 0.65rem 0.75rem;
+    border-radius: 10px;
+    border: 1px solid rgba(255, 0, 255, 0.35);
+    background: rgba(0, 0, 0, 0.55);
+    color: rgba(255, 0, 255, 0.85);
+    font-size: 0.7rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    cursor: pointer;
+    transition: border-color 0.25s ease, box-shadow 0.25s ease, transform 0.2s ease;
+}
+
+.control-deck-help-button:hover,
+.control-deck-help-button:focus {
+    border-color: rgba(255, 0, 255, 0.65);
+    box-shadow: 0 0 18px rgba(255, 0, 255, 0.25);
+    transform: translateY(-1px);
+    outline: 2px solid rgba(255, 0, 255, 0.55);
+    outline-offset: 2px;
+}
+
+.control-deck-help-button:active {
+    transform: translateY(1px);
+}
+
+.control-deck-metrics {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.75rem;
+    margin-bottom: 1rem;
+}
+
+.control-deck-metric {
+    padding: 0.75rem;
+    border-radius: 12px;
+    background: rgba(0, 255, 255, 0.06);
+    border: 1px solid rgba(0, 255, 255, 0.08);
+    text-align: center;
+    box-shadow: inset 0 0 15px rgba(0, 255, 255, 0.08);
+}
+
+.control-deck-metric-value {
+    font-size: 1.2rem;
+    font-weight: 700;
+    color: var(--neon-cyan);
+}
+
+.control-deck-metric-label {
+    margin-top: 0.4rem;
+    font-size: 0.6rem;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: rgba(0, 255, 255, 0.55);
+}
+
+.control-deck-section {
+    margin-bottom: 1rem;
+    padding: 0.75rem 0.85rem;
+    border-radius: 12px;
+    background: rgba(255, 0, 255, 0.08);
+    border: 1px solid rgba(255, 0, 255, 0.2);
+    box-shadow: inset 0 0 18px rgba(255, 0, 255, 0.12);
+}
+
+.control-deck-section-label {
+    font-size: 0.58rem;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    color: rgba(255, 0, 255, 0.6);
+}
+
+.control-deck-section-value {
+    margin-top: 0.45rem;
+    font-size: 0.85rem;
+    letter-spacing: 0.08em;
+    color: var(--crystal-teal);
+    line-height: 1.4;
+}
+
+.control-deck-tags {
+    margin-bottom: 1rem;
+}
+
+.control-deck-tags-title {
+    font-size: 0.62rem;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: rgba(0, 255, 255, 0.65);
+    margin-bottom: 0.55rem;
+}
+
+.control-deck-tag-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.45rem;
+}
+
+.control-tag-chip {
+    border: 1px solid rgba(0, 255, 255, 0.25);
+    border-radius: 999px;
+    padding: 0.35rem 0.75rem;
+    font-size: 0.58rem;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    background: rgba(0, 0, 0, 0.55);
+    color: var(--neon-cyan);
+    cursor: pointer;
+    transition: border-color 0.25s ease, background 0.25s ease, color 0.25s ease, transform 0.25s ease;
+}
+
+.control-tag-chip:hover {
+    border-color: rgba(0, 255, 255, 0.55);
+    background: rgba(0, 0, 0, 0.75);
+}
+
+.control-tag-chip.active {
+    border-color: rgba(255, 0, 255, 0.8);
+    background: rgba(255, 0, 255, 0.16);
+    color: #fff;
+    box-shadow: 0 0 22px rgba(255, 0, 255, 0.25);
+}
+
+.control-tag-chip.reset {
+    border-color: rgba(255, 255, 255, 0.18);
+    color: rgba(255, 255, 255, 0.65);
+}
+
+.control-tag-chip.reset:disabled {
+    opacity: 0.35;
+    cursor: default;
+}
+
+.control-deck-focus {
+    border: 1px solid rgba(0, 255, 170, 0.18);
+    border-radius: 12px;
+    padding: 0.9rem 0.85rem;
+    background: rgba(0, 255, 170, 0.06);
+    box-shadow: inset 0 0 18px rgba(0, 255, 170, 0.1);
+    margin-bottom: 1.05rem;
+    max-height: 260px;
+    overflow: hidden;
+}
+
+.control-deck-focus.empty {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    font-size: 0.66rem;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: rgba(0, 255, 170, 0.55);
+}
+
+.control-deck-focus-title {
+    font-size: 0.62rem;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: rgba(0, 255, 170, 0.72);
+    margin-bottom: 0.55rem;
+}
+
+.control-deck-focus-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    max-height: 190px;
+    overflow-y: auto;
+    padding-right: 0.3rem;
+}
+
+.control-deck-focus-item {
+    border: 1px solid rgba(0, 255, 170, 0.15);
+    border-radius: 10px;
+    padding: 0.55rem 0.6rem;
+    background: rgba(0, 0, 0, 0.55);
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+    transition: border-color 0.3s ease, transform 0.3s ease;
+}
+
+.control-deck-focus-item:hover {
+    border-color: rgba(0, 255, 170, 0.55);
+    transform: translateY(-2px);
+}
+
+.control-deck-focus-item.current-section {
+    border-color: rgba(255, 0, 255, 0.45);
+    box-shadow: 0 0 20px rgba(255, 0, 255, 0.22);
+}
+
+.control-deck-focus-item a {
+    color: var(--crystal-teal);
+    text-decoration: none;
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+}
+
+.control-deck-focus-meta {
+    font-size: 0.58rem;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: rgba(0, 255, 170, 0.55);
+}
+
+.control-deck-callouts {
+    display: flex;
+    flex-direction: column;
+    gap: 0.65rem;
+}
+
+.control-deck-callout {
+    border: 1px solid rgba(255, 0, 255, 0.2);
+    border-radius: 12px;
+    padding: 0.65rem 0.8rem;
+    background: rgba(0, 0, 0, 0.55);
+    font-size: 0.7rem;
+    line-height: 1.6;
+    color: rgba(255, 255, 255, 0.75);
+}
+
+.control-deck-callout::before {
+    content: '◆';
+    color: rgba(255, 0, 255, 0.8);
+    margin-right: 0.4rem;
+    font-size: 0.8rem;
+}
+
+        /* 4D POLYTOPAL VISUALIZER BACKGROUNDS */
+        .polytopal-background {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100vw;
+            height: 100vh;
+            z-index: -1;
+            opacity: 0;
+            transition: opacity 1.0s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+            /* Force CSS backgrounds to show */
+            background-size: 200% 200%, 150% 150%, cover !important;
+        }
+
+        .polytopal-background.active {
+            opacity: 0.9 !important;
+        }
+
+.polytopal-background.css-only::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at 50% 50%, rgba(0, 255, 255, 0.1) 0%, transparent 70%);
+    opacity: 0.6;
+    pointer-events: none;
+}
+
+        .polytopal-canvas {
+            width: 100%;
+            height: 100%;
+        }
+
+        /* UNIQUE POLYTOPAL THEME BACKGROUNDS */
+        #polytop-0 { /* Holographic Genesis - Magenta */
+            background: 
+                radial-gradient(circle at 20% 80%, rgba(255, 0, 255, 0.15) 0%, transparent 60%),
+                radial-gradient(circle at 80% 20%, rgba(0, 255, 170, 0.1) 0%, transparent 50%),
+                linear-gradient(45deg, rgba(13, 40, 24, 0.8) 0%, rgba(40, 0, 40, 0.8) 100%);
+            animation: magentaPulse 6s ease-in-out infinite;
+        }
+
+        #polytop-1 { /* Plasma Emergence - Cyan */
+            background: 
+                radial-gradient(circle at 60% 40%, rgba(0, 255, 255, 0.15) 0%, transparent 60%),
+                radial-gradient(circle at 30% 70%, rgba(255, 0, 77, 0.1) 0%, transparent 50%),
+                linear-gradient(135deg, rgba(0, 40, 40, 0.8) 0%, rgba(13, 40, 24, 0.8) 100%);
+            animation: cyanPulse 7s ease-in-out infinite;
+        }
+
+        #polytop-2 { /* Neural Awakening - Yellow */
+            background: 
+                radial-gradient(circle at 40% 30%, rgba(255, 255, 0, 0.15) 0%, transparent 60%),
+                radial-gradient(circle at 70% 80%, rgba(0, 128, 255, 0.1) 0%, transparent 50%),
+                linear-gradient(225deg, rgba(40, 40, 0, 0.8) 0%, rgba(13, 40, 24, 0.8) 100%);
+            animation: yellowPulse 8s ease-in-out infinite;
+        }
+
+        #polytop-3 { /* Crystal Resonance - Green */
+            background: 
+                radial-gradient(circle at 50% 60%, rgba(0, 255, 0, 0.15) 0%, transparent 60%),
+                radial-gradient(circle at 90% 10%, rgba(255, 0, 255, 0.1) 0%, transparent 50%),
+                linear-gradient(315deg, rgba(0, 40, 0, 0.8) 0%, rgba(13, 40, 24, 0.8) 100%);
+            animation: greenPulse 9s ease-in-out infinite;
+        }
+
+        #polytop-4 { /* Quantum Chaos - Orange */
+            background: 
+                radial-gradient(circle at 30% 20%, rgba(255, 128, 0, 0.15) 0%, transparent 60%),
+                radial-gradient(circle at 80% 90%, rgba(0, 255, 255, 0.1) 0%, transparent 50%),
+                linear-gradient(45deg, rgba(40, 20, 0, 0.8) 0%, rgba(13, 40, 24, 0.8) 100%);
+            animation: orangePulse 5s ease-in-out infinite;
+        }
+
+        #polytop-5 { /* Fractal Storm - Purple */
+            background: 
+                radial-gradient(circle at 70% 30%, rgba(128, 0, 255, 0.15) 0%, transparent 60%),
+                radial-gradient(circle at 20% 90%, rgba(255, 255, 0, 0.1) 0%, transparent 50%),
+                linear-gradient(135deg, rgba(20, 0, 40, 0.8) 0%, rgba(13, 40, 24, 0.8) 100%);
+            animation: purplePulse 10s ease-in-out infinite;
+        }
+
+#polytop-6 { /* Dimensional Collapse - Red */
+    background:
+        radial-gradient(circle at 90% 70%, rgba(255, 0, 0, 0.15) 0%, transparent 60%),
+        radial-gradient(circle at 10% 30%, rgba(0, 255, 0, 0.1) 0%, transparent 50%),
+        linear-gradient(225deg, rgba(40, 0, 0, 0.8) 0%, rgba(13, 40, 24, 0.8) 100%);
+    animation: redPulse 4s ease-in-out infinite;
+}
+
+body.theme-aurora #polytop-0 {
+    background:
+        radial-gradient(circle at 30% 70%, rgba(126, 251, 255, 0.2) 0%, transparent 65%),
+        radial-gradient(circle at 80% 20%, rgba(213, 123, 255, 0.18) 0%, transparent 55%),
+        linear-gradient(60deg, rgba(7, 26, 44, 0.85) 0%, rgba(32, 18, 49, 0.85) 100%);
+    animation: cyanPulse 8s ease-in-out infinite;
+}
+
+body.theme-aurora #polytop-1 {
+    background:
+        radial-gradient(circle at 65% 40%, rgba(74, 157, 255, 0.2) 0%, transparent 60%),
+        radial-gradient(circle at 25% 80%, rgba(255, 106, 193, 0.15) 0%, transparent 50%),
+        linear-gradient(120deg, rgba(9, 22, 43, 0.8) 0%, rgba(12, 32, 52, 0.85) 100%);
+    animation: magentaPulse 7s ease-in-out infinite;
+}
+
+body.theme-aurora #polytop-2 {
+    background:
+        radial-gradient(circle at 40% 30%, rgba(249, 255, 154, 0.2) 0%, transparent 60%),
+        radial-gradient(circle at 70% 70%, rgba(102, 255, 249, 0.18) 0%, transparent 50%),
+        linear-gradient(200deg, rgba(10, 28, 46, 0.8) 0%, rgba(28, 35, 68, 0.9) 100%);
+    animation: yellowPulse 9s ease-in-out infinite;
+}
+
+body.theme-aurora #polytop-3 {
+    background:
+        radial-gradient(circle at 55% 60%, rgba(126, 251, 255, 0.2) 0%, transparent 60%),
+        radial-gradient(circle at 15% 25%, rgba(213, 123, 255, 0.15) 0%, transparent 45%),
+        linear-gradient(250deg, rgba(8, 20, 42, 0.85) 0%, rgba(12, 44, 62, 0.9) 100%);
+    animation: cyanPulse 10s ease-in-out infinite;
+}
+
+body.theme-aurora #polytop-4 {
+    background:
+        radial-gradient(circle at 35% 25%, rgba(255, 106, 193, 0.18) 0%, transparent 60%),
+        radial-gradient(circle at 75% 85%, rgba(122, 251, 255, 0.18) 0%, transparent 50%),
+        linear-gradient(160deg, rgba(21, 26, 54, 0.85) 0%, rgba(44, 22, 64, 0.9) 100%);
+    animation: purplePulse 6s ease-in-out infinite;
+}
+
+body.theme-aurora #polytop-5 {
+    background:
+        radial-gradient(circle at 60% 40%, rgba(74, 157, 255, 0.2) 0%, transparent 65%),
+        radial-gradient(circle at 20% 70%, rgba(249, 255, 154, 0.15) 0%, transparent 55%),
+        linear-gradient(310deg, rgba(15, 24, 54, 0.85) 0%, rgba(30, 18, 52, 0.9) 100%);
+    animation: magentaPulse 11s ease-in-out infinite;
+}
+
+body.theme-aurora #polytop-6 {
+    background:
+        radial-gradient(circle at 70% 80%, rgba(213, 123, 255, 0.18) 0%, transparent 65%),
+        radial-gradient(circle at 15% 35%, rgba(126, 251, 255, 0.18) 0%, transparent 55%),
+        linear-gradient(45deg, rgba(12, 24, 52, 0.9) 0%, rgba(34, 16, 56, 0.92) 100%);
+    animation: purplePulse 5s ease-in-out infinite;
+}
+
+        /* CSS-Only 4D Effect Animations */
+        @keyframes magentaPulse {
+            0% { background-position: 0% 0%, 100% 100%; filter: hue-rotate(0deg) brightness(0.8); }
+            50% { background-position: 100% 50%, 0% 50%; filter: hue-rotate(30deg) brightness(1.1); }
+            100% { background-position: 0% 0%, 100% 100%; filter: hue-rotate(0deg) brightness(0.8); }
+        }
+
+        @keyframes cyanPulse {
+            0% { background-position: 50% 0%, 50% 100%; filter: hue-rotate(0deg) brightness(0.9); }
+            50% { background-position: 0% 50%, 100% 50%; filter: hue-rotate(60deg) brightness(1.2); }
+            100% { background-position: 50% 0%, 50% 100%; filter: hue-rotate(0deg) brightness(0.9); }
+        }
+
+        @keyframes yellowPulse {
+            0% { background-position: 25% 25%, 75% 75%; filter: hue-rotate(0deg) brightness(0.8); }
+            50% { background-position: 75% 25%, 25% 75%; filter: hue-rotate(45deg) brightness(1.0); }
+            100% { background-position: 25% 25%, 75% 75%; filter: hue-rotate(0deg) brightness(0.8); }
+        }
+
+        @keyframes greenPulse {
+            0% { background-position: 60% 40%, 40% 60%; filter: hue-rotate(0deg) brightness(0.9); }
+            50% { background-position: 40% 60%, 60% 40%; filter: hue-rotate(120deg) brightness(1.1); }
+            100% { background-position: 60% 40%, 40% 60%; filter: hue-rotate(0deg) brightness(0.9); }
+        }
+
+        @keyframes orangePulse {
+            0% { background-position: 80% 20%, 20% 80%; filter: hue-rotate(0deg) brightness(0.8) contrast(1.1); }
+            50% { background-position: 20% 20%, 80% 80%; filter: hue-rotate(15deg) brightness(1.3) contrast(1.2); }
+            100% { background-position: 80% 20%, 20% 80%; filter: hue-rotate(0deg) brightness(0.8) contrast(1.1); }
+        }
+
+        @keyframes purplePulse {
+            0% { background-position: 10% 90%, 90% 10%; filter: hue-rotate(0deg) brightness(0.7) saturate(1.2); }
+            50% { background-position: 90% 90%, 10% 10%; filter: hue-rotate(270deg) brightness(1.0) saturate(1.5); }
+            100% { background-position: 10% 90%, 90% 10%; filter: hue-rotate(0deg) brightness(0.7) saturate(1.2); }
+        }
+
+        @keyframes redPulse {
+            0% { background-position: 100% 0%, 0% 100%; filter: hue-rotate(0deg) brightness(0.9) contrast(1.3); }
+            50% { background-position: 0% 0%, 100% 100%; filter: hue-rotate(10deg) brightness(1.4) contrast(1.5); }
+            100% { background-position: 100% 0%, 0% 100%; filter: hue-rotate(0deg) brightness(0.9) contrast(1.3); }
+        }
+
+        /* COLLAPSIBLE NAVIGATION */
+        .nav-container {
+            position: fixed;
+            top: 0;
+            left: -280px;
+            width: 300px;
+            height: 100vh;
+            background: linear-gradient(135deg, var(--silicon-green), rgba(13, 40, 24, 0.95));
+            backdrop-filter: blur(20px);
+            z-index: 2000;
+            transition: left 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+            border-right: 2px solid var(--crystal-teal);
+            box-shadow: 
+                0 0 40px var(--crystal-teal),
+                inset -2px 0 0 rgba(0, 255, 170, 0.2),
+                -3px -3px 0 var(--accent-red),
+                3px 3px 0 var(--electric-blue);
+        }
+
+        .nav-container.open {
+            left: 0;
+        }
+
+        .nav-toggle {
+            position: fixed;
+            top: 30px;
+            left: 30px;
+            width: 50px;
+            height: 50px;
+            background: var(--silicon-green);
+            border: 2px solid var(--crystal-teal);
+            border-radius: 8px;
+            cursor: pointer;
+            z-index: 2100;
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            align-items: center;
+            gap: 4px;
+            transition: all 0.3s ease;
+            box-shadow: 
+                0 0 20px var(--crystal-teal),
+                -2px -2px 0 var(--accent-red),
+                2px 2px 0 var(--electric-blue);
+        }
+
+        .nav-toggle:hover {
+            background: rgba(0, 255, 170, 0.1);
+            box-shadow: 
+                0 0 30px var(--crystal-teal),
+                -3px -3px 0 var(--accent-red),
+                3px 3px 0 var(--electric-blue);
+            transform: scale(1.05);
+        }
+
+        .nav-toggle span {
+            width: 20px;
+            height: 2px;
+            background: var(--crystal-teal);
+            transition: all 0.3s ease;
+        }
+
+        .nav-toggle.open span:nth-child(1) {
+            transform: rotate(45deg) translate(5px, 5px);
+        }
+
+        .nav-toggle.open span:nth-child(2) {
+            opacity: 0;
+        }
+
+        .nav-toggle.open span:nth-child(3) {
+            transform: rotate(-45deg) translate(7px, -6px);
+        }
+
+        .nav-header {
+            padding: 30px 20px;
+            border-bottom: 1px solid rgba(0, 255, 170, 0.3);
+        }
+
+        .nav-title {
+            color: var(--crystal-teal);
+            font-size: 1.4em;
+            font-weight: 900;
+            text-transform: uppercase;
+            letter-spacing: 1px;
+            text-shadow: 
+                0 0 15px var(--crystal-teal),
+                -1px -1px 0 var(--accent-red),
+                1px 1px 0 var(--electric-blue);
+        }
+
+        .nav-subtitle {
+            color: var(--crystal-teal);
+            font-size: 0.8em;
+            opacity: 0.7;
+            margin-top: 5px;
+        }
+
+        .nav-sections {
+            padding: 20px 0;
+            flex-grow: 1;
+            overflow-y: auto;
+        }
+
+        .nav-section {
+            padding: 15px 20px;
+            cursor: pointer;
+            transition: all 0.3s ease;
+            border-left: 3px solid transparent;
+        }
+
+        .nav-section:hover {
+            background: rgba(0, 255, 170, 0.1);
+            border-left-color: var(--crystal-teal);
+            transform: translateX(5px);
+        }
+
+        .nav-section.active {
+            background: rgba(0, 255, 170, 0.2);
+            border-left-color: var(--crystal-teal);
+        }
+
+        .nav-section-name {
+            color: var(--crystal-teal);
+            font-size: 1.0em;
+            font-weight: bold;
+            margin-bottom: 5px;
+        }
+
+        .nav-section-info {
+            color: var(--crystal-teal);
+            font-size: 0.7em;
+            opacity: 0.6;
+        }
+
+        .nav-section-tags {
+            margin-top: 8px;
+            font-size: 0.6em;
+            letter-spacing: 0.12em;
+            text-transform: uppercase;
+            color: rgba(0, 255, 170, 0.55);
+        }
+
+        .nav-section.tag-match,
+        .nav-section.search-match {
+            background: rgba(255, 0, 255, 0.18);
+            border-left-color: rgba(255, 0, 255, 0.85);
+            box-shadow: inset 0 0 0 1px rgba(255, 0, 255, 0.25);
+        }
+
+        .nav-section.tag-muted {
+            opacity: 0.35;
+            filter: saturate(0.5);
+        }
+
+        .nav-section.search-muted {
+            opacity: 0.4;
+            filter: saturate(0.4);
+        }
+
+        /* CRYSTAL WAFER SYSTEM - 3 CARDS ONLY */
+        .crystal-container {
+            position: fixed;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+            width: 95vw;
+            max-width: 1200px;
+            height: 70vh;
+            display: grid;
+            grid-template-columns: repeat(3, 1fr);
+            grid-template-rows: 1fr;
+            gap: 30px;
+            z-index: 100;
+            perspective: 2000px;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .crystal-wafer {
+            background: linear-gradient(135deg,
+                rgba(13, 40, 24, 0.95) 0%,
+                rgba(0, 255, 170, 0.1) 25%,
+                rgba(255, 0, 77, 0.05) 50%,
+                rgba(13, 40, 24, 0.95) 100%);
+            position: relative;
+            overflow: hidden;
+            backdrop-filter: blur(25px);
+            transform-style: preserve-3d;
+            transition: all 0.8s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+            cursor: pointer;
+            display: flex;
+            flex-direction: column;
+            border-radius: 16px;
+            border: 3px solid var(--crystal-teal);
+            /* ENHANCED 3D FLOATING APPEARANCE */
+            transform: translateZ(40px) rotateX(5deg) rotateY(3deg) scale(1.0);
+            min-height: 450px;
+            padding: 25px;
+            opacity: 1.0;
+
+            box-shadow: 
+                /* Enhanced ghosting afterimage effect */
+                -8px -8px 0 var(--accent-red),
+                8px 8px 0 var(--electric-blue),
+                /* Deep crystal depth */
+                0 40px 80px rgba(0, 0, 0, 0.8),
+                0 20px 40px rgba(0, 255, 170, 0.1),
+                /* Multi-layer inner glow */
+                inset 0 3px 0 rgba(0, 255, 170, 0.2),
+                inset 0 -3px 0 rgba(255, 0, 77, 0.1);
+        }
+
+        .crystal-wafer.search-match {
+            border-color: rgba(255, 0, 255, 0.6);
+            box-shadow:
+                -8px -8px 0 rgba(255, 0, 255, 0.35),
+                8px 8px 0 rgba(0, 255, 255, 0.45),
+                0 45px 90px rgba(255, 0, 255, 0.22),
+                inset 0 0 45px rgba(255, 0, 255, 0.28),
+                inset 0 0 60px rgba(0, 255, 255, 0.2);
+        }
+
+        /* REACTIVE ENERGY BORDER SYSTEM */
+        .crystal-wafer::before {
+            content: '';
+            position: absolute;
+            top: -4px;
+            left: -4px;
+            right: -4px;
+            bottom: -4px;
+            border-radius: 16px;
+            z-index: -1;
+            pointer-events: none;
+
+            /* Reactive energy border */
+            background: 
+                linear-gradient(45deg, transparent 30%, var(--crystal-teal) 50%, transparent 70%),
+                linear-gradient(135deg, transparent 30%, var(--accent-red) 50%, transparent 70%),
+                linear-gradient(225deg, transparent 30%, var(--electric-blue) 50%, transparent 70%),
+                linear-gradient(315deg, transparent 30%, var(--neon-magenta) 50%, transparent 70%);
+
+            background-size: 400% 400%;
+            opacity: 0.3;
+            animation: energyFlow 4s ease-in-out infinite;
+        }
+
+        .crystal-wafer:hover {
+            transform: scale(1.5) translateZ(120px) rotateX(12deg) rotateY(10deg);
+            box-shadow: 
+                /* Massive ghosting afterimage */
+                -20px -20px 0 var(--accent-red),
+                20px 20px 0 var(--electric-blue),
+                /* Intense crystal resonance */
+                0 0 200px var(--crystal-teal),
+                0 0 80px var(--neon-cyan),
+                /* Treasure chest depth */
+                0 80px 160px rgba(0, 0, 0, 0.95),
+                /* Holographic inner glow */
+                inset 0 8px 0 rgba(0, 255, 170, 0.8),
+                inset 0 -8px 0 rgba(255, 0, 77, 0.3);
+            z-index: 1000;
+            border-color: var(--neon-cyan);
+        }
+
+        .crystal-wafer:hover::before {
+            opacity: 0.8;
+            animation: energyReactive 1s ease-in-out infinite;
+        }
+
+        /* HOVER FOCUS SYSTEM - SUBTLE DIM OTHER CARDS */
+        .crystal-container:hover .crystal-wafer:not(:hover) {
+            opacity: 0.7;
+            transform: scale(0.95) translateZ(-10px);
+            filter: brightness(0.8);
+            transition: all 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+        }
+
+        .crystal-wafer.tag-match {
+            border-color: rgba(255, 0, 255, 0.55);
+            box-shadow:
+                0 0 35px rgba(255, 0, 255, 0.35),
+                inset 0 0 0 1px rgba(255, 0, 255, 0.3);
+        }
+
+        .crystal-wafer.tag-match::before {
+            opacity: 0.45;
+        }
+
+        .crystal-wafer.tag-muted {
+            opacity: 0.45;
+            filter: grayscale(0.45);
+        }
+
+        .crystal-wafer.spotlight {
+            border-color: rgba(0, 255, 255, 0.85);
+            box-shadow:
+                -12px -12px 0 rgba(255, 0, 120, 0.45),
+                12px 12px 0 rgba(0, 255, 255, 0.5),
+                0 55px 110px rgba(0, 255, 255, 0.28),
+                inset 0 0 60px rgba(0, 255, 255, 0.3),
+                inset 0 0 80px rgba(255, 0, 120, 0.18);
+            transform: translateZ(60px) rotateX(7deg) rotateY(5deg) scale(1.08);
+        }
+
+        .crystal-wafer.spotlight::before {
+            opacity: 0.75;
+            animation: energyReactive 1.6s ease-in-out infinite;
+        }
+
+        /* PREVIEW ACTIVATION ON HOVER */
+        .crystal-wafer:hover .wafer-preview {
+            border-color: var(--crystal-teal);
+            box-shadow: 
+                inset 0 0 30px rgba(0, 255, 170, 0.4),
+                0 0 25px rgba(0, 255, 170, 0.3),
+                -3px -3px 0 var(--accent-red),
+                3px 3px 0 var(--electric-blue);
+            transform: scale(1.02);
+        }
+
+        /* BACKGROUND VISUALIZER SLOW DOWN ON HOVER */
+        .polytopal-background.slowed {
+            opacity: 0.4;
+            filter: blur(1px);
+            transition: all 0.8s ease;
+        }
+
+        .crystal-wafer.clicked {
+            animation: cardClick 0.6s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+        }
+
+        .crystal-wafer.clicked::before {
+            animation: energyBlast 0.6s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+        }
+
+        @keyframes energyFlow {
+            0% { 
+                background-position: 0% 50%, 0% 50%, 0% 50%, 0% 50%;
+                opacity: 0.3;
+            }
+            50% { 
+                background-position: 100% 50%, 100% 50%, 100% 50%, 100% 50%;
+                opacity: 0.5;
+            }
+            100% { 
+                background-position: 0% 50%, 0% 50%, 0% 50%, 0% 50%;
+                opacity: 0.3;
+            }
+        }
+
+        @keyframes energyReactive {
+            0% { 
+                background-position: 0% 50%, 0% 50%, 0% 50%, 0% 50%;
+                opacity: 0.8;
+                filter: blur(0px);
+            }
+            50% { 
+                background-position: 50% 0%, 50% 100%, 50% 0%, 50% 100%;
+                opacity: 1;
+                filter: blur(1px);
+            }
+            100% { 
+                background-position: 100% 50%, 100% 50%, 100% 50%, 100% 50%;
+                opacity: 0.8;
+                filter: blur(0px);
+            }
+        }
+
+        @keyframes energyBlast {
+            0% { 
+                background-position: 50% 50%, 50% 50%, 50% 50%, 50% 50%;
+                opacity: 1;
+                filter: blur(0px) brightness(1);
+                transform: scale(1);
+            }
+            50% { 
+                background-position: 100% 0%, 0% 100%, 100% 100%, 0% 0%;
+                opacity: 1.5;
+                filter: blur(3px) brightness(1.5);
+                transform: scale(1.1);
+            }
+            100% { 
+                background-position: 0% 50%, 0% 50%, 0% 50%, 0% 50%;
+                opacity: 0.3;
+                filter: blur(0px) brightness(1);
+                transform: scale(1);
+            }
+        }
+
+        @keyframes cardClick {
+            0% { transform: scale(1.08) translateZ(40px) rotateX(3deg) rotateY(3deg); }
+            25% { transform: scale(1.15) translateZ(60px) rotateX(5deg) rotateY(5deg); }
+            50% { transform: scale(1.12) translateZ(50px) rotateX(4deg) rotateY(4deg); }
+            100% { transform: scale(1.08) translateZ(40px) rotateX(3deg) rotateY(3deg); }
+        }
+
+        /* TRANSITION STATES */
+        .crystal-wafer.breaking {
+            animation: crystalBreak 0.8s ease-in forwards;
+        }
+
+        .crystal-wafer.reforming {
+            animation: crystalReform 1.0s ease-out forwards;
+        }
+
+        @keyframes crystalBreak {
+            0% { 
+                transform: scale(1) translateZ(0px) rotateY(0deg);
+                opacity: 1;
+                filter: brightness(1);
+            }
+            30% {
+                transform: scale(1.05) translateZ(20px) rotateY(10deg);
+                filter: brightness(1.3) blur(1px);
+            }
+            70% {
+                transform: scale(0.9) translateZ(-10px) rotateY(-8deg) rotateX(3deg);
+                opacity: 0.8;
+                filter: brightness(0.7) blur(2px);
+            }
+            100% { 
+                transform: scale(0.7) translateZ(-30px) rotateY(20deg) rotateX(10deg);
+                opacity: 0.4;
+                filter: brightness(0.5) blur(3px);
+            }
+        }
+
+        @keyframes crystalReform {
+            0% { 
+                transform: scale(0.7) translateZ(-30px) rotateY(-20deg) rotateX(-10deg);
+                opacity: 0.4;
+                filter: brightness(1.5) blur(3px);
+            }
+            40% {
+                transform: scale(0.95) translateZ(10px) rotateY(5deg) rotateX(2deg);
+                opacity: 0.9;
+                filter: brightness(1.2) blur(1px);
+            }
+            70% {
+                transform: scale(1.02) translateZ(15px) rotateY(-2deg);
+                opacity: 1;
+                filter: brightness(1.1);
+            }
+            100% { 
+                transform: scale(1) translateZ(0px);
+                opacity: 1;
+                filter: brightness(1);
+            }
+        }
+
+        /* NEGATIVE SPACE TEXT WITH TEAL */
+        .wafer-title {
+            position: absolute;
+            top: 15px;
+            left: 15px;
+            right: 15px;
+            font-size: 1.2em;
+            font-weight: 900;
+            text-transform: uppercase;
+            letter-spacing: 1px;
+            z-index: 10;
+
+            /* Negative space effect with teal border */
+            color: transparent;
+            -webkit-text-stroke: 2px var(--crystal-teal);
+            text-stroke: 2px var(--crystal-teal);
+
+            /* Ghosting afterimage for text */
+            text-shadow: 
+                -2px -2px 0 var(--accent-red),
+                2px 2px 0 var(--electric-blue),
+                0 0 10px var(--crystal-teal);
+        }
+
+        /* LARGE UNIFORM PREVIEW WINDOWS */
+        .wafer-preview {
+            position: absolute;
+            top: 60px;
+            left: 15px;
+            right: 15px;
+            bottom: 15px;
+            border: 2px solid var(--crystal-teal);
+            border-radius: 8px;
+            background: rgba(0, 0, 0, 0.9);
+            overflow: hidden;
+            transition: all 0.6s ease;
+            box-shadow: 
+                inset 0 0 20px rgba(0, 255, 170, 0.2),
+                0 0 15px rgba(0, 255, 170, 0.1),
+                /* Ghosting afterimage for preview frame */
+                -2px -2px 0 var(--accent-red),
+                2px 2px 0 var(--electric-blue);
+        }
+
+        .wafer-preview iframe {
+            width: 100%;
+            height: 100%;
+            border: none;
+            border-radius: 6px;
+        }
+
+        .wafer-preview.clicked {
+            animation: previewClick 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+        }
+
+        @keyframes previewClick {
+            0% { transform: scale(1); filter: brightness(1); }
+            50% { transform: scale(0.98); filter: brightness(1.3) saturate(1.5); }
+            100% { transform: scale(1); filter: brightness(1); }
+        }
+
+        /* HOVER INFO OVERLAY */
+        .wafer-info {
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background: rgba(13, 40, 24, 0.95);
+            backdrop-filter: blur(10px);
+            padding: 20px;
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            opacity: 0;
+            transform: scale(0.9);
+            transition: all 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+            z-index: 20;
+            border-radius: 12px;
+            border: 2px solid var(--crystal-teal);
+
+            /* Ghosting afterimage for info overlay */
+            box-shadow: 
+                -3px -3px 0 var(--accent-red),
+                3px 3px 0 var(--electric-blue);
+        }
+
+        .crystal-wafer:hover .wafer-info {
+            opacity: 1;
+            transform: scale(1);
+        }
+
+        .info-title {
+            color: var(--crystal-teal);
+            font-size: 1.4em;
+            font-weight: 900;
+            margin-bottom: 15px;
+            text-shadow: 
+                0 0 10px var(--crystal-teal),
+                -1px -1px 0 var(--accent-red),
+                1px 1px 0 var(--electric-blue);
+            text-transform: uppercase;
+            letter-spacing: 1px;
+        }
+
+        .info-description {
+            color: var(--crystal-teal);
+            font-size: 0.9em;
+            line-height: 1.6;
+            margin-bottom: 20px;
+            text-shadow: 0 0 5px rgba(0, 255, 170, 0.5);
+        }
+
+        .info-tags {
+            display: flex;
+            gap: 8px;
+            flex-wrap: wrap;
+            margin-top: auto;
+        }
+
+        .info-tag {
+            background: linear-gradient(45deg, rgba(255, 0, 77, 0.3), rgba(0, 255, 170, 0.3));
+            color: var(--crystal-teal);
+            padding: 4px 10px;
+            border-radius: 6px;
+            font-size: 0.7em;
+            font-weight: bold;
+            border: 1px solid var(--crystal-teal);
+            text-shadow: 0 0 5px var(--crystal-teal);
+            box-shadow: 
+                0 0 10px rgba(0, 255, 170, 0.3),
+                -1px -1px 0 var(--accent-red),
+                1px 1px 0 var(--electric-blue);
+        }
+
+        /* SECTION INDICATOR */
+        .section-indicator {
+            position: fixed;
+            top: 30px;
+            right: 30px;
+            background: var(--silicon-green);
+            border: 2px solid var(--crystal-teal);
+            border-radius: 15px;
+            padding: 20px 25px;
+            backdrop-filter: blur(20px);
+            z-index: 1000;
+            box-shadow: 
+                0 0 30px var(--crystal-teal),
+                inset 0 1px 0 rgba(0, 255, 170, 0.2),
+                -2px -2px 0 var(--accent-red),
+                2px 2px 0 var(--electric-blue);
+        }
+
+        .section-title {
+            color: var(--crystal-teal);
+            font-size: 1.3em;
+            font-weight: 900;
+            margin-bottom: 8px;
+            text-shadow: 
+                0 0 15px var(--crystal-teal),
+                -1px -1px 0 var(--accent-red),
+                1px 1px 0 var(--electric-blue);
+            text-transform: uppercase;
+            letter-spacing: 1px;
+        }
+
+        .section-subtitle {
+            color: var(--crystal-teal);
+            font-size: 0.8em;
+            opacity: 0.7;
+        }
+
+        /* MOMENTUM INDICATOR */
+        .momentum-indicator {
+            position: fixed;
+            bottom: 30px;
+            right: 30px;
+            background: var(--silicon-green);
+            border: 2px solid var(--crystal-teal);
+            border-radius: 15px;
+            padding: 15px;
+            backdrop-filter: blur(20px);
+            z-index: 1000;
+            opacity: 0;
+            transition: all 0.3s ease;
+            box-shadow: 
+                0 0 30px var(--crystal-teal),
+                inset 0 1px 0 rgba(0, 255, 170, 0.2),
+                -2px -2px 0 var(--accent-red),
+                2px 2px 0 var(--electric-blue);
+        }
+
+        .momentum-indicator.active {
+            opacity: 1;
+            transform: scale(1.05);
+        }
+
+        .momentum-title {
+            color: var(--crystal-teal);
+            font-size: 0.9em;
+            font-weight: bold;
+            margin-bottom: 8px;
+            text-transform: uppercase;
+            text-shadow: 0 0 10px var(--crystal-teal);
+        }
+
+        .momentum-bar {
+            width: 120px;
+            height: 8px;
+            background: rgba(0, 255, 170, 0.2);
+            border-radius: 4px;
+            overflow: hidden;
+            border: 1px solid var(--crystal-teal);
+        }
+
+        .momentum-fill {
+            height: 100%;
+            background: linear-gradient(90deg, var(--crystal-teal), var(--electric-blue));
+            border-radius: 4px;
+            transition: width 0.1s ease;
+            box-shadow: 0 0 10px var(--crystal-teal);
+        }
+
+        /* SITE-WIDE REACTION SYSTEM */
+        .site-reaction {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100vw;
+            height: 100vh;
+            pointer-events: none;
+            z-index: 50;
+            opacity: 0;
+            background: radial-gradient(circle at var(--click-x, 50%) var(--click-y, 50%), 
+                         rgba(0, 255, 170, 0.1) 0%, 
+                         transparent 60%);
+            animation: siteReaction 0.8s ease-out;
+        }
+
+        @keyframes siteReaction {
+            0% { 
+                opacity: 0;
+                transform: scale(0.5);
+                filter: blur(10px);
+            }
+            50% { 
+                opacity: 1;
+                transform: scale(1.2);
+                filter: blur(2px);
+            }
+            100% { 
+                opacity: 0;
+                transform: scale(2);
+                filter: blur(0px);
+            }
+        }
+
+        /* MOBILE SCROLL SNAP SYSTEM */
+        @media (max-width: 768px) {
+            body {
+                overflow-y: auto;
+                scroll-snap-type: y mandatory;
+                -webkit-overflow-scrolling: touch;
+            }
+
+            .dataset-switcher {
+                position: static;
+                margin: 1.5rem auto 0;
+                justify-content: center;
+            }
+
+            .control-deck {
+                position: relative;
+                top: 0;
+                right: 0;
+                align-items: stretch;
+                max-width: none;
+                width: calc(100% - 2.5rem);
+                margin: 1.5rem auto 0;
+            }
+
+            .control-deck-toggle {
+                justify-content: center;
+            }
+
+            .control-deck-panel {
+                width: 100%;
+                transform: none;
+            }
+
+            .control-deck-search {
+                padding: 0.75rem 0.8rem 0.85rem;
+            }
+
+            .control-deck-search-results {
+                max-height: 180px;
+            }
+
+            .control-deck-share {
+                padding: 0.75rem 0.8rem 0.85rem;
+            }
+
+            .control-deck-share-actions {
+                grid-template-columns: 1fr;
+            }
+
+            .crystal-container {
+                display: flex;
+                flex-direction: column;
+                gap: 20px;
+                width: 95vw;
+                height: auto;
+                min-height: 100vh;
+                padding: 20px 0;
+                scroll-snap-align: start;
+            }
+
+            .crystal-wafer {
+                width: 100%;
+                height: 300px;
+                scroll-snap-align: start;
+                margin-bottom: 20px;
+            }
+
+            .crystal-wafer:hover {
+                transform: scale(1.05) translateZ(20px);
+            }
+
+            .wafer-preview {
+                top: 50px;
+            }
+
+            .wafer-title {
+                font-size: 1.0em;
+            }
+
+            /* Show 3 cards per section on mobile */
+            .mobile-section {
+                display: flex;
+                flex-direction: column;
+                gap: 20px;
+                min-height: 100vh;
+                scroll-snap-align: start;
+                padding: 60px 20px 20px 20px;
+            }
+        }
+
+body.reduced-motion .polytopal-background,
+body.reduced-motion .crystal-wafer,
+body.reduced-motion .wafer-preview,
+body.reduced-motion .nav-container,
+body.reduced-motion .nav-section,
+body.reduced-motion .momentum-indicator,
+body.reduced-motion .section-indicator {
+    transition-duration: 0.001ms !important;
+    animation-duration: 0.001ms !important;
+}
+
+body.reduced-motion .crystal-wafer.spotlight::before {
+    animation: none !important;
+}
+
+body.reduced-motion .polytopal-background {
+    animation: none !important;
+    opacity: 0.7 !important;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.001ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.001ms !important;
+        scroll-behavior: auto !important;
+    }
+}
+body.shortcut-overlay-open {
+    overflow: hidden;
+}
+
+.shortcut-overlay {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 3vh 3vw;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.28s ease;
+    z-index: 240;
+}
+
+.shortcut-overlay.is-visible {
+    pointer-events: auto;
+    opacity: 1;
+}
+
+.shortcut-overlay-backdrop {
+    position: absolute;
+    inset: 0;
+    background: rgba(6, 10, 22, 0.76);
+    backdrop-filter: blur(12px);
+}
+
+.shortcut-overlay-panel {
+    position: relative;
+    width: min(960px, 96vw);
+    max-height: 88vh;
+    overflow: hidden;
+    border-radius: 22px;
+    border: 1px solid rgba(0, 255, 255, 0.25);
+    background: linear-gradient(145deg, rgba(2, 14, 28, 0.92) 0%, rgba(34, 6, 48, 0.92) 100%);
+    box-shadow: 0 45px 120px rgba(0, 0, 0, 0.45), 0 0 45px rgba(0, 255, 255, 0.2);
+    transform: translateY(30px);
+    transition: transform 0.32s ease;
+}
+
+.shortcut-overlay.is-visible .shortcut-overlay-panel {
+    transform: translateY(0);
+}
+
+.shortcut-overlay-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 1.15rem 1.35rem 0.85rem;
+    border-bottom: 1px solid rgba(0, 255, 255, 0.15);
+}
+
+.shortcut-overlay-title {
+    font-size: 1.1rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: rgba(0, 255, 255, 0.9);
+}
+
+.shortcut-overlay-close {
+    width: 2.4rem;
+    height: 2.4rem;
+    border-radius: 50%;
+    border: 1px solid rgba(255, 0, 255, 0.4);
+    background: rgba(0, 0, 0, 0.55);
+    color: rgba(255, 0, 255, 0.85);
+    font-size: 1.35rem;
+    line-height: 1;
+    cursor: pointer;
+    display: grid;
+    place-items: center;
+    transition: border-color 0.25s ease, box-shadow 0.25s ease, transform 0.2s ease;
+}
+
+.shortcut-overlay-close:hover,
+.shortcut-overlay-close:focus {
+    border-color: rgba(255, 0, 255, 0.65);
+    box-shadow: 0 0 18px rgba(255, 0, 255, 0.3);
+    transform: translateY(-1px);
+    outline: 2px solid rgba(255, 0, 255, 0.55);
+    outline-offset: 2px;
+}
+
+.shortcut-overlay-close:active {
+    transform: translateY(1px);
+}
+
+.shortcut-overlay-body {
+    overflow-y: auto;
+    padding: 1.45rem 1.35rem 1.55rem;
+}
+
+.shortcut-overlay-columns {
+    display: grid;
+    gap: 1.25rem;
+}
+
+@media (min-width: 768px) {
+    .shortcut-overlay-columns {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+}
+
+.shortcut-overlay-column {
+    background: rgba(0, 0, 0, 0.35);
+    border: 1px solid rgba(0, 255, 255, 0.14);
+    border-radius: 14px;
+    padding: 1rem 1.1rem;
+    box-shadow: inset 0 0 24px rgba(0, 255, 255, 0.08);
+}
+
+.shortcut-overlay-section h3 {
+    font-size: 0.78rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: rgba(0, 255, 255, 0.8);
+    margin-bottom: 0.7rem;
+}
+
+.shortcut-overlay-section p {
+    font-size: 0.72rem;
+    line-height: 1.6;
+    color: rgba(255, 255, 255, 0.7);
+    margin: 0 0 0.85rem;
+}
+
+.shortcut-overlay-section p:last-child {
+    margin-bottom: 0;
+}
+
+.shortcut-overlay-section dl {
+    display: grid;
+    gap: 0.65rem;
+    margin: 0;
+}
+
+.shortcut-overlay-section dl div {
+    display: grid;
+    gap: 0.35rem;
+}
+
+.shortcut-overlay-section dt {
+    font-size: 0.74rem;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: rgba(255, 0, 255, 0.8);
+}
+
+.shortcut-overlay-section dd {
+    margin: 0;
+    font-size: 0.7rem;
+    line-height: 1.5;
+    color: rgba(255, 255, 255, 0.68);
+}
+
+@media (max-width: 600px) {
+    .control-deck-preference {
+        grid-template-columns: 1fr;
+    }
+
+    .control-deck-preference input[type="checkbox"] {
+        justify-self: flex-start;
+    }
+
+    .shortcut-overlay-body {
+        padding: 1.15rem 1rem 1.3rem;
+    }
+}

--- a/gallery-aurora-system.html
+++ b/gallery-aurora-system.html
@@ -3,11 +3,11 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Visual Codex Gallery - Fixed Layout System v2.3</title>
+    <title>Visual Codex Aurora Twin System</title>
     <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>💎</text></svg>">
     <link rel="stylesheet" href="css/gallery-proper-system.css">
 </head>
-<body class="gallery-shell theme-prime" data-gallery-key="proper">
+<body class="gallery-shell theme-aurora" data-gallery-key="twin">
     <!-- 4D Polytopal Visualizer Backgrounds -->
     <div id="polytopBackgrounds">
         <!-- 7 polytopal backgrounds will be created dynamically -->
@@ -88,7 +88,7 @@
             <div class="control-deck-metrics" id="controlDeckMetrics"></div>
             <div class="control-deck-section" id="controlDeckSection">
                 <div class="control-deck-section-label">Current Section</div>
-                <div class="control-deck-section-value" id="controlDeckSectionValue">1 · Holographic Genesis</div>
+                <div class="control-deck-section-value" id="controlDeckSectionValue">1 · Aurora Bloom</div>
             </div>
             <div class="control-deck-tags">
                 <div class="control-deck-tags-title">Tag Focus</div>
@@ -102,8 +102,8 @@
     <!-- Collapsible Navigation -->
     <div class="nav-container" id="navContainer">
         <div class="nav-header">
-            <div class="nav-title">Visual Codex Proper 4D System</div>
-            <div class="nav-subtitle">4D Polytopal Visualizer</div>
+            <div class="nav-title">Visual Codex Aurora Twin</div>
+            <div class="nav-subtitle">Quantum Harmonic Array</div>
         </div>
         <div class="nav-sections" id="navSections">
             <!-- Navigation sections will be populated dynamically -->
@@ -112,8 +112,8 @@
     
     <!-- Section Indicator -->
     <div class="section-indicator">
-        <div class="section-title" id="sectionTitle">Holographic Genesis</div>
-        <div class="section-subtitle" id="sectionSubtitle">4D Polytopal Visualizer</div>
+        <div class="section-title" id="sectionTitle">Aurora Bloom</div>
+        <div class="section-subtitle" id="sectionSubtitle">Quantum Harmonic Array</div>
     </div>
     
     <!-- Momentum Indicator -->

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Visual Codex Gallery</title>
-    <meta http-equiv="refresh" content="0; url=gallery-proper-system.html">
+    <meta http-equiv="refresh" content="0; url=gallery-proper-system.html?gallery=proper">
     <style>
         body {
             background: #0a0a0f;
@@ -27,12 +27,38 @@
         .loader p {
             color: #ff00ff;
         }
+
+        .loader .links {
+            margin-top: 1.5rem;
+            display: flex;
+            gap: 1rem;
+            justify-content: center;
+        }
+
+        .loader a {
+            color: #00ffff;
+            border: 1px solid #00ffff;
+            padding: 0.5rem 1rem;
+            border-radius: 6px;
+            text-decoration: none;
+            transition: background 0.3s ease, color 0.3s ease;
+            font-weight: bold;
+        }
+
+        .loader a:hover {
+            background: rgba(0, 255, 255, 0.2);
+            color: #ff00ff;
+        }
     </style>
 </head>
 <body>
     <div class="loader">
         <h1>⚡ VISUAL CODEX</h1>
         <p>Loading enhanced 4D polytopal gallery system...</p>
+        <div class="links">
+            <a href="gallery-proper-system.html?gallery=proper">Enter Proper System</a>
+            <a href="gallery-aurora-system.html?gallery=twin">Explore Aurora Twin</a>
+        </div>
     </div>
 </body>
 </html>

--- a/js/gallery-bootstrap.js
+++ b/js/gallery-bootstrap.js
@@ -1,0 +1,230 @@
+(function () {
+  'use strict';
+
+  const STORAGE_PREFIX = 'visualCodex:v2';
+  const LAST_DATASET_KEY = `${STORAGE_PREFIX}:lastDataset`;
+
+  let storageReady;
+
+  function storageAvailable() {
+    if (typeof storageReady === 'boolean') {
+      return storageReady;
+    }
+
+    try {
+      if (typeof window === 'undefined' || !window.localStorage) {
+        storageReady = false;
+        return storageReady;
+      }
+
+      const testKey = `${STORAGE_PREFIX}:test`;
+      window.localStorage.setItem(testKey, '1');
+      window.localStorage.removeItem(testKey);
+      storageReady = true;
+    } catch (error) {
+      console.warn('⚠️ Local storage is not available for dataset persistence.', error);
+      storageReady = false;
+    }
+
+    return storageReady;
+  }
+
+  function readStoredDatasetKey(registry) {
+    if (!storageAvailable()) {
+      return null;
+    }
+
+    try {
+      const raw = window.localStorage.getItem(LAST_DATASET_KEY);
+      if (!raw || !registry || !registry[raw]) {
+        return null;
+      }
+      return raw;
+    } catch (error) {
+      console.warn('⚠️ Unable to read stored dataset key.', error);
+      return null;
+    }
+  }
+
+  function rememberDatasetKey(key) {
+    if (!key || !storageAvailable()) {
+      return;
+    }
+
+    try {
+      window.localStorage.setItem(LAST_DATASET_KEY, key);
+    } catch (error) {
+      console.warn('⚠️ Unable to persist dataset selection.', error);
+    }
+  }
+
+  function collectRegistry() {
+    const registry = window.VISUAL_CODEX_DATA || {};
+    if (!Object.keys(registry).length) {
+      console.error('❌ VISUAL_CODEX_DATA is not available or empty.');
+    }
+    return registry;
+  }
+
+  function requestedKey(defaultKey, registry) {
+    let key = defaultKey;
+    let explicitKey = null;
+
+    try {
+      const searchParams = new URLSearchParams(window.location.search);
+      explicitKey =
+        searchParams.get('gallery') ||
+        searchParams.get('dataset') ||
+        searchParams.get('mode') ||
+        null;
+
+      key = explicitKey || key;
+
+      if (key) {
+        key = key.toLowerCase();
+      }
+
+      if (!registry[key]) {
+        const hashKey = window.location.hash ? window.location.hash.substring(1).toLowerCase() : null;
+        if (hashKey && registry[hashKey]) {
+          key = hashKey;
+        }
+      }
+    } catch (error) {
+      console.warn('⚠️ Unable to parse gallery selection from URL.', error);
+    }
+
+    if (!registry[key]) {
+      const stored = readStoredDatasetKey(registry);
+      if (stored) {
+        key = stored;
+      }
+    }
+
+    return key;
+  }
+
+  function applyPageTitle(dataset) {
+    if (dataset?.pageTitle) {
+      document.title = dataset.pageTitle;
+    }
+  }
+
+  function applyTheme(dataset, registry) {
+    const body = document.body;
+    if (!body) return;
+
+    const themeClass = dataset?.themeClass;
+    Object.values(registry).forEach((entry) => {
+      if (entry?.themeClass) {
+        body.classList.remove(entry.themeClass);
+      }
+    });
+
+    if (themeClass) {
+      body.classList.add(themeClass);
+    }
+  }
+
+  function configureDatasetSwitcher(registry, activeKey) {
+    const container = document.getElementById('datasetSwitcher');
+    if (!container) return;
+
+    const currentPath = window.location.pathname;
+    const baseSearchParams = new URLSearchParams(window.location.search);
+
+    container.querySelectorAll('[data-gallery-target]').forEach((link) => {
+      const targetKey = link.dataset.galleryTarget;
+      const dataset = registry[targetKey];
+
+      if (!dataset) {
+        link.classList.add('is-disabled');
+        link.setAttribute('aria-disabled', 'true');
+        return;
+      }
+
+      link.textContent = dataset.switchLabel || dataset.title || targetKey;
+      link.classList.remove('is-disabled');
+      link.removeAttribute('aria-disabled');
+
+      const params = new URLSearchParams(baseSearchParams.toString());
+      params.set('gallery', targetKey);
+      params.delete('dataset');
+      params.delete('mode');
+      params.delete('section');
+      params.delete('wafer');
+      params.delete('card');
+
+      const queryString = params.toString();
+      link.href = queryString ? `${currentPath}?${queryString}` : currentPath;
+
+      const isActive = targetKey === activeKey;
+      link.classList.toggle('is-active', isActive);
+
+      if (isActive) {
+        link.setAttribute('aria-current', 'page');
+      } else {
+        link.removeAttribute('aria-current');
+      }
+
+      if (!link.dataset.rememberAttached) {
+        link.addEventListener('click', () => {
+          rememberDatasetKey(targetKey);
+        });
+        link.dataset.rememberAttached = 'true';
+      }
+    });
+  }
+
+  function resolveDataset() {
+    const registry = collectRegistry();
+    const defaultKey = document.body?.dataset?.galleryKey || 'proper';
+    let key = requestedKey(defaultKey, registry);
+
+    if (!registry[key]) {
+      console.warn(`⚠️ Requested dataset "${key}" is unavailable. Falling back to default.`);
+      if (registry[defaultKey]) {
+        key = defaultKey;
+      } else {
+        const firstAvailable = Object.keys(registry)[0];
+        key = firstAvailable;
+      }
+    }
+
+    const dataset = registry[key];
+    if (!dataset) {
+      console.error('❌ Unable to locate a gallery dataset.');
+      return { dataset: null, key: null, registry };
+    }
+
+    const body = document.body;
+    if (body) {
+      body.dataset.galleryKey = key;
+      body.classList.add('gallery-shell');
+    }
+
+    applyTheme(dataset, registry);
+    applyPageTitle(dataset);
+    configureDatasetSwitcher(registry, key);
+    rememberDatasetKey(key);
+
+    return { dataset, key, registry };
+  }
+
+  window.addEventListener('DOMContentLoaded', () => {
+    const { dataset, key } = resolveDataset();
+    if (!dataset) {
+      return;
+    }
+
+    if (typeof window.VisualCodexGallery !== 'function') {
+      console.error('❌ VisualCodexGallery constructor is not available.');
+      return;
+    }
+
+    console.log(`🚀 Bootstrapping Visual Codex gallery for dataset: ${key}`);
+    const gallery = new window.VisualCodexGallery(dataset);
+    gallery.startRenderLoop();
+    window.visualCodexGallery = gallery;
+  });
+})();

--- a/js/gallery-content.js
+++ b/js/gallery-content.js
@@ -1,0 +1,700 @@
+(function () {
+  const properContentSets = [
+    [
+      {
+        "title": "Neoskeuomorphic",
+        "description": "Modern depth-based card design with advanced shadow systems and interactive hover states",
+        "tags": ["CSS", "Design", "Cards"],
+        "url": "demos/neoskeuomorphic-cards-demo.html",
+        "name": "Neoskeuomorphic Cards"
+      },
+      {
+        "title": "Glassmorphism",
+        "description": "Translucent glass-like interface elements with backdrop blur and transparency",
+        "tags": ["CSS", "Glass", "Modern"],
+        "url": "demos/css-glassmorphism-demo.html",
+        "name": "Glassmorphism UI"
+      },
+      {
+        "title": "Holographic Progress",
+        "description": "Futuristic progress indicators with neon glow effects and smooth animations",
+        "tags": ["CSS", "Progress", "Neon"],
+        "url": "demos/holographic-progress-indicators-demo.html",
+        "name": "Holographic Progress"
+      },
+      {
+        "title": "State Control",
+        "description": "Interactive navigation dot systems with smooth state transitions",
+        "tags": ["CSS", "Controls", "Interactive"],
+        "url": "demos/state-control-dots-demo.html",
+        "name": "State Control Dots"
+      },
+      {
+        "title": "Vaporwave",
+        "description": "Retro-futuristic aesthetic elements with classic 80s styling",
+        "tags": ["CSS", "Retro", "Aesthetic"],
+        "url": "demos/css-vaporwave-aesthetics-demo.html",
+        "name": "Vaporwave Aesthetics"
+      },
+      {
+        "title": "Grid Overlay",
+        "description": "Dynamic grid pattern animations with morphing geometric structures",
+        "tags": ["CSS", "Grid", "Animation"],
+        "url": "demos/animated-grid-overlay-demo.html",
+        "name": "Animated Grid Overlay"
+      }
+    ],
+    [
+      {
+        "title": "Holographic Visualizer",
+        "description": "Multi-layer WebGL blend mode system with depth-based holographic effects",
+        "tags": ["WebGL", "Holographic", "Blend"],
+        "url": "effects/holographic-visualizer.html",
+        "name": "Holographic Visualizer"
+      },
+      {
+        "title": "Cyberpunk UI",
+        "description": "Futuristic interface design elements with neon highlights and tech aesthetics",
+        "tags": ["CSS", "Cyberpunk", "Interface"],
+        "url": "demos/css-cyberpunk-ui-demo.html",
+        "name": "Cyberpunk UI"
+      },
+      {
+        "title": "Particle System",
+        "description": "Advanced particle physics visualization with 3D depth and movement",
+        "tags": ["WebGL", "Particles", "Physics"],
+        "url": "demos/holographic-particle-system-demo.html",
+        "name": "Particle System"
+      },
+      {
+        "title": "Glitch Effects",
+        "description": "Digital corruption and distortion effects with RGB channel separation",
+        "tags": ["CSS", "Glitch", "Digital"],
+        "url": "demos/css-glitch-effects-demo.html",
+        "name": "Glitch Effects"
+      },
+      {
+        "title": "Depth Layers",
+        "description": "Multi-dimensional depth visualization with parallax scrolling effects",
+        "tags": ["CSS", "Depth", "Layers"],
+        "url": "demos/holographic-depth-layers-demo.html",
+        "name": "Depth Layers"
+      },
+      {
+        "title": "Adaptive Cards",
+        "description": "Dynamic responsive card system with intelligent layout adaptation",
+        "tags": ["CSS", "Adaptive", "Responsive"],
+        "url": "demos/vib34d-adaptive-cards-demo.html",
+        "name": "VIB34D Adaptive Cards"
+      }
+    ],
+    [
+      {
+        "title": "MVEP Hypercube",
+        "description": "4D hypercube with interference patterns and mathematical precision",
+        "tags": ["WebGL", "4D", "Hypercube"],
+        "url": "effects/mvep-moire-hypercube.html",
+        "name": "MVEP Hypercube"
+      },
+      {
+        "title": "Hypercube Codex",
+        "description": "Advanced 4D mathematical visualization with interactive rotation controls",
+        "tags": ["WebGL", "Math", "4D"],
+        "url": "demos/moire-hypercube-codex-demo.html",
+        "name": "Hypercube Codex"
+      },
+      {
+        "title": "Lattice Visualizer",
+        "description": "Geometric lattice structure system with crystalline formations",
+        "tags": ["WebGL", "Lattice", "Geometry"],
+        "url": "demos/hypercube-lattice-visualizer-demo.html",
+        "name": "Lattice Visualizer"
+      },
+      {
+        "title": "Chaos Overlay",
+        "description": "Digital interference and chaos patterns with algorithmic generation",
+        "tags": ["WebGL", "Chaos", "Interference"],
+        "url": "demos/chaos-overlay-effects-demo.html",
+        "name": "Chaos Overlay"
+      },
+      {
+        "title": "Orchestration Engine",
+        "description": "Coordinated multi-system visualization with synchronized behaviors",
+        "tags": ["WebGL", "System", "Orchestra"],
+        "url": "demos/system-orchestration-engine-demo.html",
+        "name": "System Orchestration"
+      },
+      {
+        "title": "Reactive Core",
+        "description": "Reactive state management system with real-time data visualization",
+        "tags": ["WebGL", "Reactive", "Core"],
+        "url": "demos/vib3code-reactive-core-demo.html",
+        "name": "VIB3Code Reactive Core"
+      }
+    ],
+    [
+      {
+        "title": "VIB34D Complete",
+        "description": "Revolutionary 4D framework with 8+ geometric systems and advanced rendering",
+        "tags": ["WebGL", "VIB34D", "Framework"],
+        "url": "effects/vib34d-complete-system.html",
+        "name": "VIB34D Complete System"
+      },
+      {
+        "title": "4D HyperAV",
+        "description": "Proven 4D audiovisual system with synchronized sound and visuals",
+        "tags": ["WebGL", "4D", "Audio"],
+        "url": "effects/working-4d-hyperav.html",
+        "name": "4D HyperAV"
+      },
+      {
+        "title": "Core Framework",
+        "description": "Core 4D mathematics framework with optimized projection algorithms",
+        "tags": ["WebGL", "Core", "Math"],
+        "url": "effects/hypercube-core-framework.html",
+        "name": "Hypercube Core Framework"
+      },
+      {
+        "title": "Consciousness Shader",
+        "description": "N-dimensional consciousness visualization with abstract thought patterns",
+        "tags": ["WebGL", "Polytopal", "Consciousness"],
+        "url": "demos/polytopal-consciousness-shader-demo.html",
+        "name": "Polytopal Consciousness"
+      },
+      {
+        "title": "Elegant 4D Flow",
+        "description": "Graceful 4D particle systems with fluid dynamics",
+        "tags": ["WebGL", "4D", "Flow"],
+        "url": "effects/elegant-4d-flow-visualizer.html",
+        "name": "Elegant 4D Flow"
+      },
+      {
+        "title": "Holographic Pulse",
+        "description": "Rhythmic holographic pulse visualization system",
+        "tags": ["WebGL", "Holographic", "Pulse"],
+        "url": "effects/holographic-pulse-system.html",
+        "name": "Holographic Pulse"
+      }
+    ],
+    [
+      {
+        "title": "Hyperdimensional Matrix",
+        "description": "8D+ chaos visualization with fractal tessellations and infinite complexity",
+        "tags": ["WebGL", "8D", "Chaos"],
+        "url": "effects/insane-hyperdimensional-matrix.html",
+        "name": "Hyperdimensional Matrix"
+      },
+      {
+        "title": "Card Bending",
+        "description": "Advanced 3D CSS transform morphing with 6 unique bending behaviors",
+        "tags": ["CSS", "3D", "Morphing"],
+        "url": "effects/vib34d-advanced-card-bending-system.html",
+        "name": "VIB34D Card Bending"
+      },
+      {
+        "title": "Color Shift",
+        "description": "Extreme filter effects with contrast shifts and chromatic aberration",
+        "tags": ["CSS", "Color", "Filters"],
+        "url": "effects/enhanced-color-shift-contrast-system.html",
+        "name": "Enhanced Color Shift"
+      },
+      {
+        "title": "Maleficarum Codex",
+        "description": "Advanced magical interface system with spell-casting interactions",
+        "tags": ["WebGL", "Magic", "Interface"],
+        "url": "demos/millzmaleficarum-codex-demo.html",
+        "name": "Millzmaleficarum Codex"
+      },
+      {
+        "title": "Morphing Blog",
+        "description": "Dynamic content morphing system with seamless transitions",
+        "tags": ["WebGL", "Morphing", "Blog"],
+        "url": "demos/vib34d-morphing-blog-demo.html",
+        "name": "VIB34D Morphing Blog"
+      },
+      {
+        "title": "Multi Canvas",
+        "description": "Multiple synchronized visualizer instances with coordinated behaviors",
+        "tags": ["WebGL", "Multi", "Canvas"],
+        "url": "effects/multi-canvas-visualizer-system.html",
+        "name": "Multi Canvas System"
+      }
+    ],
+    [
+      {
+        "title": "Narrative Choreography",
+        "description": "JSON-driven scroll transformations with story-based interactions",
+        "tags": ["WebGL", "Narrative", "Choreography"],
+        "url": "effects/narrative-choreography-engine.html",
+        "name": "Narrative Choreography"
+      },
+      {
+        "title": "Tabbed Visualizer",
+        "description": "Advanced WebGL tab management with state preservation",
+        "tags": ["WebGL", "Tabs", "Management"],
+        "url": "effects/tabbed-visualizer-system.html",
+        "name": "Tabbed Visualizer"
+      },
+      {
+        "title": "WebGL Framework",
+        "description": "High-performance shader framework with optimization algorithms",
+        "tags": ["WebGL", "Framework", "Performance"],
+        "url": "effects/hypercube-core-webgl-framework.html",
+        "name": "WebGL Framework"
+      },
+      {
+        "title": "Digital Magazine",
+        "description": "Interactive digital publication with immersive page transitions",
+        "tags": ["WebGL", "Magazine", "Interactive"],
+        "url": "demos/vib3code-digital-magazine-demo.html",
+        "name": "VIB3Code Digital Magazine"
+      },
+      {
+        "title": "Tech Layout",
+        "description": "Advanced layout with active systems and dynamic positioning",
+        "tags": ["WebGL", "Layout", "Tech"],
+        "url": "demos/tech-layout-active-holographic-demo.html",
+        "name": "Tech Layout Active"
+      },
+      {
+        "title": "Parallax Systems",
+        "description": "Advanced parallax visualization with infinite depth perception",
+        "tags": ["WebGL", "Parallax", "System"],
+        "url": "demos/holographic-parallax-systems-mega-demo.html",
+        "name": "Holographic Parallax"
+      }
+    ],
+    [
+      {
+        "title": "Active Holographic",
+        "description": "125 WebGL visualizers in mega-demo with coordinated chaos",
+        "tags": ["WebGL", "Mega", "Active"],
+        "url": "demos/active-holographic-systems-mega-demo.html",
+        "name": "Active Holographic Mega",
+        "isHeavy": true
+      },
+      {
+        "title": "VIB34D Complete",
+        "description": "Revolutionary 4D framework with all geometric systems enabled",
+        "tags": ["WebGL", "VIB34D", "Complete"],
+        "url": "effects/vib34d-complete-system.html",
+        "name": "VIB34D Complete"
+      },
+      {
+        "title": "Working 4D HyperAV",
+        "description": "Proven audiovisual 4D system with synchronized rendering",
+        "tags": ["WebGL", "4D", "Audio"],
+        "url": "effects/working-4d-hyperav.html",
+        "name": "Working 4D HyperAV"
+      },
+      {
+        "title": "Hypercube Core",
+        "description": "Core hypercube framework with mathematical precision",
+        "tags": ["WebGL", "Hypercube", "Core"],
+        "url": "effects/hypercube-core-framework.html",
+        "name": "Hypercube Core"
+      },
+      {
+        "title": "Insane Matrix",
+        "description": "8D+ hyperdimensional chaos with infinite complexity",
+        "tags": ["WebGL", "8D", "Matrix"],
+        "url": "effects/insane-hyperdimensional-matrix.html",
+        "name": "Hyperdimensional Matrix"
+      },
+      {
+        "title": "MVEP Hypercube",
+        "description": "Production MVEP system with moire interference patterns",
+        "tags": ["WebGL", "MVEP", "Hypercube"],
+        "url": "effects/mvep-moire-hypercube.html",
+        "name": "MVEP Moire Hypercube"
+      }
+    ]
+  ];
+
+  const properPolytopThemes = [
+    { "name": "Holographic Genesis", "slug": "holographic-genesis", "geometry": "hypercube", "rotation": [0.3, 0.2, 0.4, 0.1], "density": 5.0, "colors": [1.0, 0.0, 1.0] },
+    { "name": "Plasma Emergence", "slug": "plasma-emergence", "geometry": "octaplex", "rotation": [0.4, 0.3, 0.2, 0.5], "density": 6.5, "colors": [0.0, 1.0, 1.0] },
+    { "name": "Neural Awakening", "slug": "neural-awakening", "geometry": "16cell", "rotation": [0.2, 0.5, 0.3, 0.4], "density": 8.0, "colors": [1.0, 1.0, 0.0] },
+    { "name": "Crystal Resonance", "slug": "crystal-resonance", "geometry": "120cell", "rotation": [0.5, 0.1, 0.6, 0.2], "density": 10.0, "colors": [0.0, 1.0, 0.0] },
+    { "name": "Quantum Chaos", "slug": "quantum-chaos", "geometry": "600cell", "rotation": [0.6, 0.4, 0.1, 0.7], "density": 12.5, "colors": [1.0, 0.5, 0.0] },
+    { "name": "Fractal Storm", "slug": "fractal-storm", "geometry": "tesseract", "rotation": [0.7, 0.6, 0.5, 0.3], "density": 15.0, "colors": [0.5, 0.0, 1.0] },
+    { "name": "Dimensional Collapse", "slug": "dimensional-collapse", "geometry": "polytope", "rotation": [0.8, 0.7, 0.6, 0.8], "density": 20.0, "colors": [1.0, 0.0, 0.0] }
+  ];
+
+  const twinContentSets = [
+    [
+      {
+        title: "Crystal Prism Nexus",
+        description: "Refined wafer formations showcasing crystalline depth layering for desktop curation",
+        tags: ["Gallery", "Crystal", "Desktop"],
+        url: "gallery-crystal-wafer.html",
+        name: "Crystal Wafer Array"
+      },
+      {
+        title: "Treasure Vault Relay",
+        description: "Immersive scroll experience blending treasure chamber lighting with holographic reveals",
+        tags: ["Gallery", "Scroll", "Immersive"],
+        url: "gallery-treasure-experience.html",
+        name: "Treasure Experience"
+      },
+      {
+        title: "Snap Grid Corridor",
+        description: "Momentum-guided snap scrolling corridor with rhythmic camera locks and neon anchors",
+        tags: ["Gallery", "Scroll", "Momentum"],
+        url: "gallery-snap-scroll.html",
+        name: "Snap Scroll Gallery"
+      },
+      {
+        title: "Tactile Field",
+        description: "Haptic-inspired scroll physics translated into glass-panel transitions for tactile control",
+        tags: ["Gallery", "Tactile", "Physics"],
+        url: "gallery-tactile-scroll.html",
+        name: "Tactile Scroll"
+      },
+      {
+        title: "Parallax Observatory",
+        description: "Multi-depth parallax showcase with orbital camera sweeps and reactive focus nodes",
+        tags: ["Gallery", "Parallax", "Depth"],
+        url: "gallery-parallax-system.html",
+        name: "Parallax System"
+      },
+      {
+        title: "Crystal Lattice Revision",
+        description: "Iterated wafer refinement demonstrating calibrated lighting and panel choreography",
+        tags: ["Gallery", "Crystal", "Revision"],
+        url: "gallery-crystal-perfected.html",
+        name: "Crystal Wafer Perfected"
+      }
+    ],
+    [
+      {
+        title: "Native Holo Deck",
+        description: "Original mobile-first interface with low-latency transitions and tap-driven parallax",
+        tags: ["Mobile", "Gallery", "Native"],
+        url: "gallery-mobile-native.html",
+        name: "Mobile Native"
+      },
+      {
+        title: "Enhanced Vapor Core",
+        description: "Upgraded mobile gallery with expanded preview cells and neon fog overlays",
+        tags: ["Mobile", "Enhancement", "Fog"],
+        url: "gallery-mobile-enhanced.html",
+        name: "Mobile Enhanced"
+      },
+      {
+        title: "Six by Seven Array",
+        description: "High-density 6x7 lattice optimized for fingertip scanning and rapid loading",
+        tags: ["Mobile", "Grid", "Performance"],
+        url: "gallery-mobile-native-6x7.html",
+        name: "Mobile 6x7"
+      },
+      {
+        title: "Server Relay Portal",
+        description: "Local server landing view with diagnostic overlays for gallery orchestration",
+        tags: ["Ops", "Server", "Diagnostics"],
+        url: "gallery-server.html",
+        name: "Server Portal"
+      },
+      {
+        title: "Standalone Capsule",
+        description: "Minimalist standalone deployment with capsule transitions and quick boot",
+        tags: ["Deployment", "Standalone", "Minimal"],
+        url: "gallery-standalone.html",
+        name: "Standalone Gallery"
+      },
+      {
+        title: "Prime Gallery",
+        description: "Primary aggregated gallery entry with curated hover preloads and matrix layout",
+        tags: ["Gallery", "Aggregate", "Curated"],
+        url: "gallery.html",
+        name: "Main Gallery"
+      }
+    ],
+    [
+      {
+        title: "Production Spectacular",
+        description: "VIB34D stage show with sequenced reveals and cinematic gradient choreography",
+        tags: ["VIB34D", "Showcase", "Cinematic"],
+        url: "demos/vib34d-production-spectacular-demo.html",
+        name: "Production Spectacular"
+      },
+      {
+        title: "Director Console",
+        description: "Command dashboard for orchestrating multiple VIB pipelines with editor-grade overlays",
+        tags: ["VIB34D", "Dashboard", "Control"],
+        url: "demos/vib34d-editor-dashboard-demo.html",
+        name: "Editor Dashboard"
+      },
+      {
+        title: "Mega Systems Hub",
+        description: "Tabbed control surface for cycling between packed active holographic clusters",
+        tags: ["Holographic", "Tabs", "Control"],
+        url: "demos/active-holographic-systems-tabbed.html",
+        name: "Tabbed Holographic Hub"
+      },
+      {
+        title: "Mobile Control Dots",
+        description: "Touch-optimized navigation dots with inertia curves and mobile telemetry",
+        tags: ["Mobile", "Navigation", "Control"],
+        url: "demos/state-control-dots-mobile.html",
+        name: "State Dots Mobile"
+      },
+      {
+        title: "Pocket Cards",
+        description: "Compact neoskeuomorphic card pack tuned for handset rendering budgets",
+        tags: ["Mobile", "Cards", "Depth"],
+        url: "demos/neoskeuomorphic-cards-mobile.html",
+        name: "Cards Mobile"
+      },
+      {
+        title: "Index Redirect",
+        description: "Zero-latency redirect entry for handing users into the polytopal selector",
+        tags: ["Routing", "Bootstrap", "Redirect"],
+        url: "index.html",
+        name: "Index Redirect"
+      }
+    ],
+    [
+      {
+        title: "Complete Enhanced",
+        description: "Elevated VIB34D core featuring additional shader stacks and colorway cycling",
+        tags: ["VIB34D", "Enhanced", "Shaders"],
+        url: "effects/vib34d-complete-system-enhanced.html",
+        name: "Complete Enhanced"
+      },
+      {
+        title: "Hypercube Weave",
+        description: "Hypercube lattice weaving variant emphasising structural resonance",
+        tags: ["WebGL", "Hypercube", "Resonance"],
+        url: "effects/mvep-moire-hypercube.html",
+        name: "Hypercube Weave"
+      },
+      {
+        title: "Pulse Harmonics",
+        description: "Holographic pulse retimed for harmonic layering and multi-channel glow",
+        tags: ["WebGL", "Pulse", "Audio"],
+        url: "effects/holographic-pulse-system.html",
+        name: "Pulse Harmonics"
+      },
+      {
+        title: "Flow Atlas",
+        description: "Fluid atlas variant emphasising ribboned particle striations and curl maps",
+        tags: ["WebGL", "Flow", "Particles"],
+        url: "effects/elegant-4d-flow-visualizer.html",
+        name: "Flow Atlas"
+      },
+      {
+        title: "Matrix Storm",
+        description: "Hyperdimensional matrix tuned for stormfront intensity and turbulence",
+        tags: ["WebGL", "Matrix", "Chaos"],
+        url: "effects/insane-hyperdimensional-matrix.html",
+        name: "Matrix Storm"
+      },
+      {
+        title: "Narrative Shell",
+        description: "Story engine variant with extended timeline curves and chapter cues",
+        tags: ["WebGL", "Narrative", "Engine"],
+        url: "effects/narrative-choreography-engine.html",
+        name: "Narrative Engine"
+      }
+    ],
+    [
+      {
+        title: "Iframe Diagnostics",
+        description: "Diagnostics pass for lazy iframe hydration and sandbox verification",
+        tags: ["Testing", "Iframe", "Diagnostics"],
+        url: "test-iframe-loading.html",
+        name: "Iframe Diagnostics"
+      },
+      {
+        title: "Gallery Bootstrap",
+        description: "Python launcher manifest for orchestrating local gallery servers",
+        tags: ["Ops", "Launcher", "Python"],
+        url: "start-gallery.py",
+        name: "Start Gallery Script",
+        isHeavy: true
+      },
+      {
+        title: "Comprehensive Mobile Test",
+        description: "Automated Puppeteer sweep covering mobile layout assertions and scroll cases",
+        tags: ["Testing", "Mobile", "Automation"],
+        url: "test-mobile-gallery-comprehensive.js",
+        name: "Mobile Test Full",
+        isHeavy: true
+      },
+      {
+        title: "Quick Mobile Test",
+        description: "Lightweight smoke test script verifying mission-critical gallery endpoints",
+        tags: ["Testing", "Smoke", "Automation"],
+        url: "test-mobile-gallery-quick.js",
+        name: "Mobile Test Quick",
+        isHeavy: true
+      },
+      {
+        title: "Server Automation",
+        description: "Batch bootstrap for gallery server spin-up with instrumentation hooks",
+        tags: ["Ops", "Server", "Bootstrap"],
+        url: "start-gallery.bat",
+        name: "Server Bootstrap",
+        isHeavy: true
+      },
+      {
+        title: "Puppeteer Harness",
+        description: "Headless harness validating iframe sequencing and fallback states",
+        tags: ["Testing", "Harness", "Automation"],
+        url: "test-gallery-puppeteer.js",
+        name: "Puppeteer Harness",
+        isHeavy: true
+      }
+    ],
+    [
+      {
+        title: "Adaptive Cards Alt",
+        description: "Alternate adaptive card arrangement showcasing color-coded zones",
+        tags: ["CSS", "Adaptive", "Alt"],
+        url: "demos/vib34d-adaptive-cards-demo.html",
+        name: "Adaptive Cards Alt"
+      },
+      {
+        title: "Glassmorphism Drift",
+        description: "Glass surfaces retuned for colder palette and additional motion blur",
+        tags: ["CSS", "Glass", "Variant"],
+        url: "demos/css-glassmorphism-demo.html",
+        name: "Glassmorphism Drift"
+      },
+      {
+        title: "Cyberpunk Switchback",
+        description: "Cyberpunk UI variant focusing on alert channels and status ribbons",
+        tags: ["CSS", "Cyberpunk", "Variant"],
+        url: "demos/css-cyberpunk-ui-demo.html",
+        name: "Cyberpunk Switchback"
+      },
+      {
+        title: "Particle Bloom",
+        description: "Particle system emphasising bloom intensity and camera drift",
+        tags: ["WebGL", "Particles", "Bloom"],
+        url: "demos/holographic-particle-system-demo.html",
+        name: "Particle Bloom"
+      },
+      {
+        title: "Glitch Strata",
+        description: "Glitch showcase focusing on layered tearing and chroma abrasion",
+        tags: ["CSS", "Glitch", "Variant"],
+        url: "demos/css-glitch-effects-demo.html",
+        name: "Glitch Strata"
+      },
+      {
+        title: "Depth Chamber",
+        description: "Depth layers retimed for breathing motion and extended parallax",
+        tags: ["CSS", "Depth", "Variant"],
+        url: "demos/holographic-depth-layers-demo.html",
+        name: "Depth Chamber"
+      }
+    ],
+    [
+      {
+        title: "Active Resonance",
+        description: "Mega system focusing on resonance mapping and system overload visuals",
+        tags: ["WebGL", "Mega", "Resonance"],
+        url: "demos/active-holographic-systems-mega-demo.html",
+        name: "Active Resonance",
+        isHeavy: true
+      },
+      {
+        title: "Core Lattice",
+        description: "Hypercube core variant tuned for lattice clarity and axis markers",
+        tags: ["WebGL", "Core", "Lattice"],
+        url: "effects/hypercube-core-framework.html",
+        name: "Core Lattice"
+      },
+      {
+        title: "Moire Field",
+        description: "Moire hypercube reinterpreted with focus on interference envelopes",
+        tags: ["WebGL", "Moire", "Field"],
+        url: "effects/mvep-moire-hypercube.html",
+        name: "Moire Field"
+      },
+      {
+        title: "Pulse Array",
+        description: "Pulse system reconfigured as stacked array for multi-channel output",
+        tags: ["WebGL", "Pulse", "Array"],
+        url: "effects/holographic-pulse-system.html",
+        name: "Pulse Array"
+      },
+      {
+        title: "Matrix Collapse",
+        description: "Hyperdimensional matrix pushed to collapse threshold for glitch cascades",
+        tags: ["WebGL", "Matrix", "Collapse"],
+        url: "effects/insane-hyperdimensional-matrix.html",
+        name: "Matrix Collapse"
+      },
+      {
+        title: "Hypercube Audio",
+        description: "Working HyperAV variant focusing on audio waveform integration",
+        tags: ["WebGL", "Audio", "Hypercube"],
+        url: "effects/working-4d-hyperav.html",
+        name: "HyperAV Audio"
+      }
+    ]
+  ];
+
+  const twinPolytopThemes = [
+    { name: "Aurora Bloom", slug: "aurora-bloom", geometry: "stellated", rotation: [0.25, 0.45, 0.3, 0.55], density: 6.0, colors: [0.5, 0.9, 1.0] },
+    { name: "Singularity Drift", slug: "singularity-drift", geometry: "polychoron", rotation: [0.6, 0.25, 0.5, 0.35], density: 7.8, colors: [0.7, 0.6, 1.0] },
+    { name: "Celestial Lattice", slug: "celestial-lattice", geometry: "starcell", rotation: [0.35, 0.6, 0.4, 0.2], density: 9.4, colors: [0.6, 0.85, 1.0] },
+    { name: "Spectral Cascade", slug: "spectral-cascade", geometry: "aurora", rotation: [0.55, 0.3, 0.65, 0.4], density: 11.0, colors: [0.8, 0.7, 1.0] },
+    { name: "Nebula Circuit", slug: "nebula-circuit", geometry: "quantum", rotation: [0.7, 0.5, 0.25, 0.6], density: 13.2, colors: [0.5, 0.7, 1.0] },
+    { name: "Prismatic Flux", slug: "prismatic-flux", geometry: "lumen", rotation: [0.65, 0.7, 0.55, 0.3], density: 16.5, colors: [0.9, 0.6, 1.0] },
+    { name: "Eventide Echo", slug: "eventide-echo", geometry: "nocturne", rotation: [0.75, 0.8, 0.6, 0.7], density: 19.8, colors: [0.7, 0.5, 1.0] }
+  ];
+
+  const proper = {
+    key: "proper",
+    title: "Visual Codex Proper 4D System",
+    subtitle: "4D Polytopal Visualizer",
+    tagline: "Polytopal Command Array",
+    logPrefix: "Visual Codex Proper 4D System v2.3",
+    pageTitle: "Visual Codex Gallery — Proper System",
+    themeClass: "theme-prime",
+    switchLabel: "Proper System",
+    summary: "Flagship Visual Codex dataset emphasizing high-energy WebGL polytopes with momentum-driven navigation.",
+    callouts: [
+      "Seven crystalline visualizer environments tuned for desktop laboratory viewing.",
+      "Momentum scroll physics drive the wafer choreography with WebGL-first staging.",
+      "Automated mega-system handling keeps the heaviest demos accessible with safe previews."
+    ],
+    heavyPreview: {
+      label: "⚡ MEGA SYSTEM",
+      button: "◆ Launch System",
+      description: ["125 WebGL visualizers"]
+    },
+    contentSets: properContentSets,
+    polytopThemes: properPolytopThemes
+  };
+
+  const twin = {
+    key: "twin",
+    title: "Visual Codex Aurora Twin",
+    subtitle: "Quantum Harmonic Array",
+    tagline: "Quantum Harmonic Ops Deck",
+    logPrefix: "Visual Codex Aurora Twin System",
+    pageTitle: "Visual Codex Gallery — Aurora Twin",
+    themeClass: "theme-aurora",
+    switchLabel: "Aurora Twin",
+    summary: "Aurora twin dataset curating tooling, mobile-first variants, and diagnostics to contrast every original showcase.",
+    callouts: [
+      "Every selection mirrors the proper system with alternate outcomes or platform focuses.",
+      "Includes operations portals, mobile decks, and variant renders for each major system.",
+      "Tag analytics surface specialization zones for rapid exploration across the codex."
+    ],
+    heavyPreview: {
+      label: "⚙ Automation Artifact",
+      button: "◆ Open Resource",
+      description: ["Tooling & diagnostics payload"]
+    },
+    contentSets: twinContentSets,
+    polytopThemes: twinPolytopThemes
+  };
+
+  window.VISUAL_CODEX_DATA = Object.freeze({ proper, twin });
+})();

--- a/js/gallery-renderer.js
+++ b/js/gallery-renderer.js
@@ -1,0 +1,2903 @@
+(function () {
+  "use strict";
+
+class PolytopBackgroundVisualizer {
+            constructor(canvas, theme, sectionIndex) {
+                this.canvas = canvas;
+                this.theme = theme;
+                this.sectionIndex = sectionIndex;
+                
+                // Force WebGL context creation with all possible options
+                const contextOptions = {
+                    alpha: true,
+                    depth: true,
+                    stencil: false,
+                    antialias: true,
+                    premultipliedAlpha: false,
+                    preserveDrawingBuffer: false,
+                    powerPreference: "default",
+                    failIfMajorPerformanceCaveat: false
+                };
+                
+                this.gl = canvas.getContext('webgl', contextOptions) || 
+                         canvas.getContext('experimental-webgl', contextOptions) ||
+                         canvas.getContext('webkit-3d', contextOptions) ||
+                         canvas.getContext('moz-webgl', contextOptions);
+                
+                if (!this.gl) {
+                    console.error(`❌ FORCING WebGL for visualizer ${sectionIndex} - trying alternative approaches`);
+                    
+                    // Try without options
+                    this.gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');
+                    
+                    if (!this.gl) {
+                        console.error(`❌ WebGL completely failed for visualizer ${sectionIndex}`);
+                        console.error(`Canvas dimensions: ${canvas.width}x${canvas.height}`);
+                        console.error(`Canvas parent:`, canvas.parentElement);
+                        throw new Error('WebGL not available');
+                    }
+                }
+                
+                console.log(`🎯 FORCING WebGL context for visualizer ${sectionIndex}: ${theme.name}`);
+                console.log(`  - WebGL version: ${this.gl.getParameter(this.gl.VERSION)}`);
+                console.log(`  - Renderer: ${this.gl.getParameter(this.gl.RENDERER)}`);
+                console.log(`  - Vendor: ${this.gl.getParameter(this.gl.VENDOR)}`);
+                console.log(`  - Canvas: ${canvas.width}x${canvas.height}`);
+                
+                this.mouseX = 0.5;
+                this.mouseY = 0.5;
+                this.mouseIntensity = 0.0;
+                this.scrollProgress = 0.0;
+                this.timeScale = 1.0;
+                
+                this.startTime = Date.now();
+                this.initShaders();
+                this.initBuffers();
+                this.resize();
+                
+                console.log(`💎 Polytopal Visualizer ${sectionIndex}: ${theme.name} (${theme.geometry})`);
+            }
+            
+            initShaders() {
+                const vertexShaderSource = `
+                    attribute vec2 a_position;
+                    void main() {
+                        gl_Position = vec4(a_position, 0.0, 1.0);
+                    }
+                `;
+                
+                const fragmentShaderSource = `
+                    precision highp float;
+                    
+                    uniform vec2 u_resolution;
+                    uniform float u_time;
+                    uniform vec2 u_mouse;
+                    uniform float u_geometry;
+                    uniform float u_density;
+                    uniform vec4 u_rotation;
+                    uniform vec3 u_color;
+                    uniform float u_mouseIntensity;
+                    uniform float u_scrollProgress;
+                    
+                    // 4D rotation matrices for polytopal projections
+                    mat4 rotateXW(float theta) {
+                        float c = cos(theta);
+                        float s = sin(theta);
+                        return mat4(c, 0, 0, -s, 0, 1, 0, 0, 0, 0, 1, 0, s, 0, 0, c);
+                    }
+                    
+                    mat4 rotateYW(float theta) {
+                        float c = cos(theta);
+                        float s = sin(theta);
+                        return mat4(1, 0, 0, 0, 0, c, 0, -s, 0, 0, 1, 0, 0, s, 0, c);
+                    }
+                    
+                    mat4 rotateZW(float theta) {
+                        float c = cos(theta);
+                        float s = sin(theta);
+                        return mat4(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, c, -s, 0, 0, s, c);
+                    }
+                    
+                    mat4 rotateXY(float theta) {
+                        float c = cos(theta);
+                        float s = sin(theta);
+                        return mat4(c, -s, 0, 0, s, c, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);
+                    }
+                    
+                    vec3 project4Dto3D(vec4 p) {
+                        float w = 2.0 / (2.0 + p.w + u_scrollProgress * 0.5);
+                        return vec3(p.x * w, p.y * w, p.z * w);
+                    }
+                    
+                    // Advanced polytopal geometry functions
+                    float hypercubeLattice(vec3 p, float gridSize) {
+                        vec3 grid = fract(p * gridSize);
+                        vec3 edges = 1.0 - smoothstep(0.0, 0.02, abs(grid - 0.5));
+                        float corners = length(grid - 0.5);
+                        corners = 1.0 - smoothstep(0.0, 0.3, corners);
+                        return max(max(max(edges.x, edges.y), edges.z), corners * 0.6);
+                    }
+                    
+                    float octaplexLattice(vec3 p, float gridSize) {
+                        vec3 q = fract(p * gridSize) - 0.5;
+                        
+                        // 8 vertices of octaplex
+                        float d1 = length(q - vec3(0.5, 0.0, 0.0));
+                        float d2 = length(q - vec3(-0.5, 0.0, 0.0));
+                        float d3 = length(q - vec3(0.0, 0.5, 0.0));
+                        float d4 = length(q - vec3(0.0, -0.5, 0.0));
+                        float d5 = length(q - vec3(0.0, 0.0, 0.5));
+                        float d6 = length(q - vec3(0.0, 0.0, -0.5));
+                        
+                        float minDist = min(min(min(d1, d2), min(d3, d4)), min(d5, d6));
+                        return 1.0 - smoothstep(0.0, 0.2, minDist);
+                    }
+                    
+                    float cell16Lattice(vec3 p, float gridSize) {
+                        vec3 q = fract(p * gridSize) - 0.5;
+                        
+                        // 16-cell vertices (4D cross-polytope projection)
+                        float lattice = 0.0;
+                        for (int i = 0; i < 4; i++) {
+                            float fi = float(i);
+                            vec3 vertex = vec3(
+                                cos(fi * 1.57) * 0.3,
+                                sin(fi * 1.57) * 0.3,
+                                cos(fi * 3.14) * 0.2
+                            );
+                            float dist = length(q - vertex);
+                            lattice += exp(-dist * 8.0);
+                        }
+                        return lattice;
+                    }
+                    
+                    float cell120Lattice(vec3 p, float gridSize) {
+                        vec3 q = fract(p * gridSize) - 0.5;
+                        
+                        // 120-cell approximation with dodecahedral symmetry
+                        float lattice = 0.0;
+                        float phi = 1.618033988; // golden ratio
+                        
+                        // Icosahedral vertices
+                        for (int i = 0; i < 12; i++) {
+                            float fi = float(i);
+                            float angle = fi * 0.5236; // pi/6
+                            vec3 vertex = vec3(
+                                cos(angle) / phi * 0.4,
+                                sin(angle) / phi * 0.4,
+                                sin(angle * 2.0) * 0.3
+                            );
+                            float dist = length(q - vertex);
+                            lattice += exp(-dist * 6.0);
+                        }
+                        return lattice;
+                    }
+                    
+                    float cell600Lattice(vec3 p, float gridSize) {
+                        vec3 q = fract(p * gridSize) - 0.5;
+                        
+                        // 600-cell approximation (most complex regular polytope)
+                        float lattice = 0.0;
+                        float phi = 1.618033988;
+                        
+                        // Complex vertex arrangement
+                        for (int i = 0; i < 20; i++) {
+                            float fi = float(i);
+                            float angle1 = fi * 0.314159; // pi/10
+                            float angle2 = fi * 0.628318; // pi/5
+                            
+                            vec3 vertex = vec3(
+                                cos(angle1) * phi * 0.2,
+                                sin(angle1) * phi * 0.2,
+                                cos(angle2) * 0.3
+                            );
+                            float dist = length(q - vertex);
+                            lattice += exp(-dist * 4.0);
+                        }
+                        return lattice;
+                    }
+                    
+                    float tesseractLattice(vec3 p, float gridSize) {
+                        vec3 q = fract(p * gridSize) - 0.5;
+                        
+                        // Tesseract (8-cell) vertices - manual calculation
+                        float lattice = 0.0;
+                        
+                        // Calculate 8 cube vertices manually
+                        lattice += 1.0 - smoothstep(0.0, 0.25, length(q - vec3(-0.3, -0.3, -0.3)));
+                        lattice += 1.0 - smoothstep(0.0, 0.25, length(q - vec3( 0.3, -0.3, -0.3)));
+                        lattice += 1.0 - smoothstep(0.0, 0.25, length(q - vec3(-0.3,  0.3, -0.3)));
+                        lattice += 1.0 - smoothstep(0.0, 0.25, length(q - vec3( 0.3,  0.3, -0.3)));
+                        lattice += 1.0 - smoothstep(0.0, 0.25, length(q - vec3(-0.3, -0.3,  0.3)));
+                        lattice += 1.0 - smoothstep(0.0, 0.25, length(q - vec3( 0.3, -0.3,  0.3)));
+                        lattice += 1.0 - smoothstep(0.0, 0.25, length(q - vec3(-0.3,  0.3,  0.3)));
+                        lattice += 1.0 - smoothstep(0.0, 0.25, length(q - vec3( 0.3,  0.3,  0.3)));
+                        
+                        return lattice;
+                    }
+                    
+                    float polytopeLattice(vec3 p, float gridSize) {
+                        vec3 q = fract(p * gridSize) - 0.5;
+                        
+                        // General polytope with complex symmetries
+                        float lattice = 0.0;
+                        
+                        // Multiple symmetry groups
+                        for (int i = 0; i < 16; i++) {
+                            float fi = float(i);
+                            float angle = fi * 0.39269908; // 2*pi/16
+                            
+                            vec3 vertex = vec3(
+                                cos(angle) * 0.4,
+                                sin(angle) * 0.4,
+                                cos(angle * 3.0) * 0.3
+                            );
+                            
+                            float dist = length(q - vertex);
+                            lattice += exp(-dist * 5.0) * (1.0 + cos(fi));
+                        }
+                        
+                        return lattice;
+                    }
+                    
+                    float getPolytopValue(vec3 p, float density, float geomType) {
+                        if (geomType < 0.5) return hypercubeLattice(p, density);
+                        else if (geomType < 1.5) return octaplexLattice(p, density);
+                        else if (geomType < 2.5) return cell16Lattice(p, density);
+                        else if (geomType < 3.5) return cell120Lattice(p, density);
+                        else if (geomType < 4.5) return cell600Lattice(p, density);
+                        else if (geomType < 5.5) return tesseractLattice(p, density);
+                        else return polytopeLattice(p, density);
+                    }
+                    
+                    vec3 hsv2rgb(vec3 c) {
+                        vec4 K = vec4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);
+                        vec3 p = abs(fract(c.xxx + K.xyz) * 6.0 - K.www);
+                        return c.z * mix(K.xxx, clamp(p - K.xxx, 0.0, 1.0), c.y);
+                    }
+                    
+                    void main() {
+                        vec2 uv = gl_FragCoord.xy / u_resolution.xy;
+                        float aspectRatio = u_resolution.x / u_resolution.y;
+                        uv.x *= aspectRatio;
+                        uv -= 0.5;
+                        
+                        // Time-based rotation with scroll influence
+                        float time = u_time * 0.0005;
+                        
+                        // Mouse influence on 4D space
+                        vec2 mouseOffset = (u_mouse - 0.5) * u_mouseIntensity * 0.5;
+                        
+                        // 4D space with scroll-influenced depth
+                        vec4 p4d = vec4(
+                            uv.x + mouseOffset.x, 
+                            uv.y + mouseOffset.y,
+                            sin(time + u_scrollProgress) * 0.3, 
+                            cos(time + u_scrollProgress) * 0.3
+                        );
+                        
+                        // Multi-axis 4D rotations with mathematical grace
+                        p4d = rotateXW(time * u_rotation.x + u_scrollProgress * 0.5) * p4d;
+                        p4d = rotateYW(time * u_rotation.y + u_mouseIntensity * 0.3) * p4d;
+                        p4d = rotateZW(time * u_rotation.z + u_scrollProgress * 0.3) * p4d;
+                        p4d = rotateXY(time * u_rotation.w + u_mouseIntensity * 0.2) * p4d;
+                        
+                        vec3 p = project4Dto3D(p4d);
+                        
+                        // Scroll-influenced density
+                        float density = u_density * (1.0 + u_scrollProgress * 0.5);
+                        
+                        // Get polytopal value
+                        float polytop = getPolytopValue(p, density, u_geometry);
+                        
+                        // Color based on polytope and interactions
+                        float baseHue = atan(u_color.r, u_color.g) + u_scrollProgress * 0.2;
+                        float hue = baseHue + u_mouseIntensity * 0.3;
+                        float saturation = 0.8 + polytop * 0.2;
+                        float brightness = 0.3 + polytop * 0.7 + u_mouseIntensity * 0.2;
+                        
+                        vec3 color = hsv2rgb(vec3(hue, saturation, brightness));
+                        
+                        // Mouse interaction glow
+                        float mouseDist = length(uv - mouseOffset);
+                        float mouseGlow = exp(-mouseDist * 3.0) * u_mouseIntensity * 0.3;
+                        color += vec3(mouseGlow) * u_color;
+                        
+                        gl_FragColor = vec4(color, 0.8);
+                    }
+                `;
+                
+                this.program = this.createProgram(vertexShaderSource, fragmentShaderSource);
+                this.uniforms = {
+                    resolution: this.gl.getUniformLocation(this.program, 'u_resolution'),
+                    time: this.gl.getUniformLocation(this.program, 'u_time'),
+                    mouse: this.gl.getUniformLocation(this.program, 'u_mouse'),
+                    geometry: this.gl.getUniformLocation(this.program, 'u_geometry'),
+                    density: this.gl.getUniformLocation(this.program, 'u_density'),
+                    rotation: this.gl.getUniformLocation(this.program, 'u_rotation'),
+                    color: this.gl.getUniformLocation(this.program, 'u_color'),
+                    mouseIntensity: this.gl.getUniformLocation(this.program, 'u_mouseIntensity'),
+                    scrollProgress: this.gl.getUniformLocation(this.program, 'u_scrollProgress')
+                };
+            }
+            
+            createProgram(vertexSource, fragmentSource) {
+                const vertexShader = this.createShader(this.gl.VERTEX_SHADER, vertexSource);
+                const fragmentShader = this.createShader(this.gl.FRAGMENT_SHADER, fragmentSource);
+                
+                const program = this.gl.createProgram();
+                this.gl.attachShader(program, vertexShader);
+                this.gl.attachShader(program, fragmentShader);
+                this.gl.linkProgram(program);
+                
+                if (!this.gl.getProgramParameter(program, this.gl.LINK_STATUS)) {
+                    console.error('Program linking failed:', this.gl.getProgramInfoLog(program));
+                    return null;
+                }
+                
+                return program;
+            }
+            
+            createShader(type, source) {
+                const shader = this.gl.createShader(type);
+                this.gl.shaderSource(shader, source);
+                this.gl.compileShader(shader);
+                
+                if (!this.gl.getShaderParameter(shader, this.gl.COMPILE_STATUS)) {
+                    console.error('Shader compilation failed:', this.gl.getShaderInfoLog(shader));
+                    return null;
+                }
+                
+                return shader;
+            }
+            
+            initBuffers() {
+                const positions = new Float32Array([-1, -1, 1, -1, -1, 1, 1, 1]);
+                
+                this.buffer = this.gl.createBuffer();
+                this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this.buffer);
+                this.gl.bufferData(this.gl.ARRAY_BUFFER, positions, this.gl.STATIC_DRAW);
+                
+                const positionLocation = this.gl.getAttribLocation(this.program, 'a_position');
+                this.gl.enableVertexAttribArray(positionLocation);
+                this.gl.vertexAttribPointer(positionLocation, 2, this.gl.FLOAT, false, 0, 0);
+            }
+            
+            resize() {
+                this.canvas.width = window.innerWidth;
+                this.canvas.height = window.innerHeight;
+                this.gl.viewport(0, 0, this.canvas.width, this.canvas.height);
+            }
+            
+            updateInteraction(mouseX, mouseY, intensity) {
+                this.mouseX = mouseX;
+                this.mouseY = mouseY;
+                this.mouseIntensity = intensity;
+            }
+            
+            updateScroll(scrollProgress) {
+                this.scrollProgress = scrollProgress;
+            }
+            
+            setTimeScale(scale) {
+                this.timeScale = scale;
+            }
+            
+            render() {
+                if (!this.program) return;
+                
+                this.resize();
+                this.gl.useProgram(this.program);
+                
+                const time = (Date.now() - this.startTime) * (this.timeScale || 1.0);
+                
+                // Set uniforms
+                this.gl.uniform2f(this.uniforms.resolution, this.canvas.width, this.canvas.height);
+                this.gl.uniform1f(this.uniforms.time, time);
+                this.gl.uniform2f(this.uniforms.mouse, this.mouseX, this.mouseY);
+                this.gl.uniform1f(this.uniforms.geometry, this.sectionIndex);
+                this.gl.uniform1f(this.uniforms.density, this.theme.density);
+                this.gl.uniform4fv(this.uniforms.rotation, new Float32Array(this.theme.rotation));
+                this.gl.uniform3fv(this.uniforms.color, new Float32Array(this.theme.colors));
+                this.gl.uniform1f(this.uniforms.mouseIntensity, this.mouseIntensity);
+                this.gl.uniform1f(this.uniforms.scrollProgress, this.scrollProgress);
+                
+                this.gl.drawArrays(this.gl.TRIANGLE_STRIP, 0, 4);
+            }
+        }
+        
+        // PROPER SYSTEM MANAGER
+        class VisualCodexGallery {
+            constructor(dataset, options = {}) {
+                this.data = dataset || {};
+                this.options = options;
+
+                this.contentSets = Array.isArray(this.data.contentSets) ? this.data.contentSets : [];
+                this.polytopThemes = Array.isArray(this.data.polytopThemes) ? this.data.polytopThemes : [];
+                this.subtitle = this.data.subtitle || '4D Polytopal Visualizer';
+                this.navTitle = this.data.title || 'Visual Codex';
+                this.logPrefix = this.data.logPrefix || 'Visual Codex System';
+                this.tagline = this.data.tagline || this.subtitle;
+                this.summary = this.data.summary || '';
+                this.callouts = Array.isArray(this.data.callouts) ? this.data.callouts : [];
+                this.baseControlDeckStatus = this.subtitle;
+                this.heavyPreview = {
+                    label: '⚡ MEGA SYSTEM',
+                    button: '◆ Launch System',
+                    description: ['125 WebGL visualizers'],
+                    ...(this.data.heavyPreview || {})
+                };
+                this.sectionTagSets = this.computeSectionTagSets();
+                this.tagIndex = this.buildTagIndex();
+                this.searchIndex = this.buildSearchIndex();
+                this.metrics = this.computeMetrics();
+                this.activeTagFilter = null;
+                this.activeSearchQuery = '';
+                this.activeSearchDisplayValue = '';
+                this.searchResults = [];
+                this.searchSectionMatches = new Set();
+                this.searchCardMatches = new Map();
+                this.searchResultKeySet = new Set();
+                this.navSections = [];
+
+                this.sectionSlugs = this.buildSectionSlugs();
+                this.sectionSlugMap = this.buildSectionSlugMap(this.sectionSlugs);
+
+                this.storageAvailable = this.checkStorageAvailability();
+                this.preferenceKey = this.buildPreferenceKey();
+                this.preferences = this.loadPreferences();
+                this.rememberViewEnabled = this.preferences.rememberView !== false;
+                this.restoringState = false;
+                this.initialTagFilter = null;
+                this.initialSearchValue = '';
+                this.initialDeckOpen = false;
+                this.lastFocusedElement = null;
+                this.shortcutOverlay = null;
+
+                const initialTarget = this.parseLocationForTarget();
+
+                if (this.rememberViewEnabled) {
+                    const storedSection = typeof this.preferences.lastSection === 'number' ? this.preferences.lastSection : null;
+                    if (initialTarget.sectionIndex === null && storedSection !== null) {
+                        initialTarget.sectionIndex = storedSection;
+                    }
+
+                    const storedWafer = typeof this.preferences.lastWafer === 'number' ? this.preferences.lastWafer : null;
+                    if (initialTarget.waferIndex === null && storedWafer !== null && storedWafer >= 0 && storedWafer < 3) {
+                        initialTarget.waferIndex = storedWafer;
+                    }
+
+                    if (typeof this.preferences.lastTag === 'string' && this.preferences.lastTag.trim()) {
+                        this.initialTagFilter = this.preferences.lastTag.trim();
+                    }
+
+                    if (typeof this.preferences.lastSearch === 'string') {
+                        this.initialSearchValue = this.preferences.lastSearch;
+                    }
+                }
+
+                const resolvedSection = typeof initialTarget.sectionIndex === 'number'
+                    ? this.clampSectionIndex(initialTarget.sectionIndex)
+                    : 0;
+
+                this.currentSection = resolvedSection;
+                this.spotlightWaferIndex = typeof initialTarget.waferIndex === 'number'
+                    ? initialTarget.waferIndex
+                    : null;
+
+                if (typeof this.spotlightWaferIndex === 'number') {
+                    if (this.spotlightWaferIndex < 0 || this.spotlightWaferIndex > 2) {
+                        this.spotlightWaferIndex = null;
+                    }
+                }
+
+                if (this.initialTagFilter && (!this.metrics || !this.metrics.tagCounts || !this.metrics.tagCounts.has(this.initialTagFilter))) {
+                    this.initialTagFilter = null;
+                }
+
+                if (this.initialTagFilter) {
+                    this.activeTagFilter = this.initialTagFilter;
+                }
+
+                this.initialSearchValue = typeof this.initialSearchValue === 'string' ? this.initialSearchValue : '';
+                this.initialDeckOpen = Boolean(this.preferences.autoOpenDeck) || (this.rememberViewEnabled && Boolean(this.preferences.deckOpen));
+
+                this.scrollMomentum = 0;
+                this.isTransitioning = false;
+                this.momentumThreshold = options.momentumThreshold ?? 25;
+                this.polytopVisualizers = [];
+                this.mouseX = 0.5;
+                this.mouseY = 0.5;
+                this.mouseIntensity = 0.0;
+                this.motionMediaQuery = window.matchMedia ? window.matchMedia('(prefers-reduced-motion: reduce)') : null;
+                this.reducedMotion = options.forceReducedMotion ?? Boolean(this.motionMediaQuery && this.motionMediaQuery.matches);
+                this.webglAvailable = false;
+                this.renderLoopId = null;
+                this.historyInitialized = false;
+                this.suppressHistoryUpdate = false;
+                this.shareStatusEl = null;
+                this.boundPopStateHandler = this.handlePopState.bind(this);
+                this.boundHashChangeHandler = () => this.handlePopState();
+
+                if (this.motionMediaQuery) {
+                    const handler = (event) => {
+                        this.reducedMotion = event.matches;
+                        this.handleMotionPreferenceChange();
+                    };
+
+                    if (typeof this.motionMediaQuery.addEventListener === 'function') {
+                        this.motionMediaQuery.addEventListener('change', handler);
+                    } else if (typeof this.motionMediaQuery.addListener === 'function') {
+                        this.motionMediaQuery.addListener(handler);
+                    }
+                }
+
+                this.initialize();
+            }
+
+            initialize() {
+                console.log(`💎 Initializing ${this.logPrefix}...`);
+
+                if (this.reducedMotion) {
+                    document.body.classList.add('reduced-motion');
+                    console.log('♿ Reduced motion preference detected - using CSS-first rendering mode.');
+                } else {
+                    document.body.classList.remove('reduced-motion');
+                }
+
+                this.applyMetadata();
+                this.createPolytopBackgrounds();
+                this.createCrystalWafers();
+                this.createNavigation();
+                this.createControlDeck();
+                this.setupInteractions();
+                this.updateContent();
+                this.updateNavigation();
+                this.updateUI();
+
+                console.log('✅ System ready - 4D polytopal visualizers with reactive energy borders');
+            }
+
+            applyMetadata() {
+                const navTitleEl = document.querySelector('.nav-title');
+                const navSubtitleEl = document.querySelector('.nav-subtitle');
+                if (navTitleEl) navTitleEl.textContent = this.navTitle;
+                if (navSubtitleEl) navSubtitleEl.textContent = this.subtitle;
+                const subtitleIndicator = document.getElementById('sectionSubtitle');
+                if (subtitleIndicator) subtitleIndicator.textContent = this.subtitle;
+            }
+
+            buildPreferenceKey() {
+                const datasetKey = this.data?.key || document.body?.dataset?.galleryKey || 'dataset';
+                return `visualCodex:v2:preferences:${datasetKey}`;
+            }
+
+            checkStorageAvailability() {
+                try {
+                    if (typeof window === 'undefined' || !window.localStorage) {
+                        return false;
+                    }
+
+                    const testKey = `${this.buildPreferenceKey()}:test`;
+                    window.localStorage.setItem(testKey, '1');
+                    window.localStorage.removeItem(testKey);
+                    return true;
+                } catch (error) {
+                    console.warn('⚠️ Local storage unavailable for gallery preferences.', error);
+                    return false;
+                }
+            }
+
+            loadPreferences() {
+                const defaults = {
+                    rememberView: true,
+                    autoOpenDeck: false,
+                    lastSection: null,
+                    lastWafer: null,
+                    lastTag: null,
+                    lastSearch: '',
+                    deckOpen: false
+                };
+
+                if (!this.storageAvailable) {
+                    return { ...defaults };
+                }
+
+                try {
+                    const raw = window.localStorage.getItem(this.preferenceKey);
+                    if (!raw) {
+                        return { ...defaults };
+                    }
+
+                    const parsed = JSON.parse(raw);
+                    if (!parsed || typeof parsed !== 'object') {
+                        return { ...defaults };
+                    }
+
+                    return { ...defaults, ...parsed };
+                } catch (error) {
+                    console.warn('⚠️ Unable to load gallery preferences.', error);
+                    return { ...defaults };
+                }
+            }
+
+            savePreferences(patch = {}, options = {}) {
+                const { force = false, skipStorage = false } = options || {};
+                const next = { ...this.preferences, ...patch };
+                this.preferences = next;
+
+                if ((this.restoringState && !force) || skipStorage || !this.storageAvailable) {
+                    return next;
+                }
+
+                try {
+                    window.localStorage.setItem(this.preferenceKey, JSON.stringify(next));
+                } catch (error) {
+                    console.warn('⚠️ Unable to persist gallery preferences.', error);
+                }
+
+                return next;
+            }
+
+            persistViewState() {
+                if (!this.rememberViewEnabled) {
+                    return;
+                }
+
+                const deckOpen = Boolean(this.controlDeck && this.controlDeck.deck && this.controlDeck.deck.classList.contains('open'));
+                const searchValue = this.activeSearchDisplayValue || (this.activeSearchQuery ? this.activeSearchQuery : '');
+
+                this.savePreferences({
+                    lastSection: this.currentSection,
+                    lastWafer: typeof this.spotlightWaferIndex === 'number' ? this.spotlightWaferIndex : null,
+                    lastTag: this.activeTagFilter || null,
+                    lastSearch: searchValue,
+                    deckOpen
+                });
+            }
+
+            clearRememberedView() {
+                this.savePreferences({
+                    lastSection: null,
+                    lastWafer: null,
+                    lastTag: null,
+                    lastSearch: '',
+                    deckOpen: false
+                }, { force: true });
+            }
+
+            computeSectionTagSets() {
+                if (!Array.isArray(this.contentSets)) {
+                    return [];
+                }
+
+                return this.contentSets.map((section) => {
+                    const tags = new Set();
+
+                    if (Array.isArray(section)) {
+                        section.forEach((item) => {
+                            if (!item || !Array.isArray(item.tags)) {
+                                return;
+                            }
+
+                            item.tags.forEach((tag) => {
+                                if (typeof tag === 'string' && tag.trim()) {
+                                    tags.add(tag.trim());
+                                }
+                            });
+                        });
+                    }
+
+                    return tags;
+                });
+            }
+
+            buildTagIndex() {
+                const index = new Map();
+
+                if (!Array.isArray(this.contentSets)) {
+                    return index;
+                }
+
+                this.contentSets.forEach((section, sectionIndex) => {
+                    if (!Array.isArray(section)) {
+                        return;
+                    }
+
+                    section.forEach((item, cardIndex) => {
+                        if (!item) {
+                            return;
+                        }
+
+                        const tags = Array.isArray(item.tags) ? item.tags : [];
+                        tags.forEach((tag) => {
+                            if (typeof tag !== 'string' || !tag.trim()) {
+                                return;
+                            }
+
+                            const normalized = tag.trim();
+                            if (!index.has(normalized)) {
+                                index.set(normalized, []);
+                            }
+
+                            index.get(normalized).push({
+                                sectionIndex,
+                                cardIndex,
+                                title: item.title || item.name || `Entry ${cardIndex + 1}`,
+                                url: item.url || '#',
+                                description: item.description || ''
+                            });
+                        });
+                    });
+                });
+
+                return index;
+            }
+
+            buildSearchIndex() {
+                const index = [];
+
+                if (!Array.isArray(this.contentSets)) {
+                    return index;
+                }
+
+                this.contentSets.forEach((section, sectionIndex) => {
+                    if (!Array.isArray(section)) {
+                        return;
+                    }
+
+                    section.forEach((item, cardIndex) => {
+                        if (!item) {
+                            return;
+                        }
+
+                        const title = item.title || item.name || `Entry ${cardIndex + 1}`;
+                        const description = item.description || '';
+                        const tags = Array.isArray(item.tags) ? item.tags : [];
+                        const tagText = tags.join(' ');
+                        const searchText = `${title} ${description} ${tagText}`.toLowerCase();
+
+                        index.push({
+                            sectionIndex,
+                            cardIndex,
+                            title,
+                            description,
+                            tags,
+                            url: item.url || '#',
+                            searchText
+                        });
+                    });
+                });
+
+                return index;
+            }
+
+            buildSectionSlugs() {
+                if (!Array.isArray(this.polytopThemes) || !this.polytopThemes.length) {
+                    return [];
+                }
+
+                const slugs = [];
+                const seen = new Map();
+
+                this.polytopThemes.forEach((theme, index) => {
+                    const rawValue = (theme && typeof theme.slug === 'string' && theme.slug.trim())
+                        ? theme.slug
+                        : theme?.name;
+                    const baseSlug = this.normalizeSlugValue(rawValue, index);
+                    let slug = baseSlug;
+                    let attempt = 2;
+
+                    while (seen.has(slug)) {
+                        slug = `${baseSlug}-${attempt++}`;
+                    }
+
+                    seen.set(slug, true);
+                    slugs.push(slug);
+                });
+
+                return slugs;
+            }
+
+            buildSectionSlugMap(slugs) {
+                const map = new Map();
+
+                if (!Array.isArray(slugs)) {
+                    return map;
+                }
+
+                slugs.forEach((slug, index) => {
+                    if (typeof slug === 'string' && slug.trim()) {
+                        map.set(slug, index);
+                    }
+                });
+
+                return map;
+            }
+
+            normalizeSlugValue(value, index) {
+                if (typeof value === 'string' && value.trim()) {
+                    return value
+                        .trim()
+                        .toLowerCase()
+                        .replace(/[^a-z0-9]+/g, '-')
+                        .replace(/^-+|-+$/g, '') || `section-${index + 1}`;
+                }
+
+                return `section-${index + 1}`;
+            }
+
+            clampSectionIndex(index) {
+                if (typeof index !== 'number' || Number.isNaN(index)) {
+                    return 0;
+                }
+
+                const maxIndex = Math.max(0, this.polytopThemes.length - 1);
+                if (!Number.isFinite(maxIndex)) {
+                    return 0;
+                }
+
+                return Math.min(Math.max(index, 0), maxIndex);
+            }
+
+            parseLocationForTarget(location = window.location) {
+                const result = { sectionIndex: null, waferIndex: null };
+
+                if (!location) {
+                    return result;
+                }
+
+                try {
+                    const params = new URLSearchParams(location.search || '');
+                    const sectionParam = params.get('section') || params.get('focus');
+                    const waferParam = params.get('wafer') || params.get('card');
+
+                    if (sectionParam) {
+                        const normalized = this.normalizeSlugValue(sectionParam, 0);
+                        if (this.sectionSlugMap && this.sectionSlugMap.has(normalized)) {
+                            result.sectionIndex = this.sectionSlugMap.get(normalized);
+                        }
+                    }
+
+                    if (waferParam) {
+                        const waferNumber = parseInt(waferParam, 10);
+                        if (!Number.isNaN(waferNumber)) {
+                            const zeroIndex = waferNumber - 1;
+                            if (zeroIndex >= 0 && zeroIndex < 3) {
+                                result.waferIndex = zeroIndex;
+                            }
+                        }
+                    }
+
+                    const hashValue = (location.hash || '').replace(/^#/, '');
+                    if (result.sectionIndex === null && hashValue) {
+                        const sectionMatch = hashValue.match(/section-([a-z0-9-]+)/i);
+                        const extracted = sectionMatch ? sectionMatch[1].toLowerCase() : hashValue.toLowerCase();
+                        if (this.sectionSlugMap && this.sectionSlugMap.has(extracted)) {
+                            result.sectionIndex = this.sectionSlugMap.get(extracted);
+                        }
+                    }
+
+                    if (result.waferIndex === null && hashValue) {
+                        const waferMatch = hashValue.match(/wafer-(\d+)/i);
+                        if (waferMatch) {
+                            const zeroIndex = parseInt(waferMatch[1], 10) - 1;
+                            if (!Number.isNaN(zeroIndex) && zeroIndex >= 0 && zeroIndex < 3) {
+                                result.waferIndex = zeroIndex;
+                            }
+                        }
+                    }
+                } catch (error) {
+                    console.warn('⚠️ Unable to parse deep link target from location.', error);
+                }
+
+                return result;
+            }
+
+            computeMetrics() {
+                const metrics = {
+                    totalSections: Array.isArray(this.contentSets) ? this.contentSets.length : 0,
+                    totalEntries: 0,
+                    webgl: 0,
+                    css: 0,
+                    gallery: 0,
+                    mobile: 0,
+                    tagCounts: new Map(),
+                    tagList: []
+                };
+
+                if (!Array.isArray(this.contentSets)) {
+                    return metrics;
+                }
+
+                this.contentSets.forEach((section) => {
+                    if (!Array.isArray(section)) {
+                        return;
+                    }
+
+                    section.forEach((item) => {
+                        if (!item) {
+                            return;
+                        }
+
+                        metrics.totalEntries += 1;
+
+                        const tags = Array.isArray(item.tags) ? item.tags : [];
+                        tags.forEach((tag) => {
+                            if (typeof tag !== 'string' || !tag.trim()) {
+                                return;
+                            }
+
+                            const normalized = tag.trim();
+                            metrics.tagCounts.set(normalized, (metrics.tagCounts.get(normalized) || 0) + 1);
+                        });
+
+                        if (tags.includes('WebGL')) metrics.webgl += 1;
+                        if (tags.includes('CSS')) metrics.css += 1;
+                        if (tags.includes('Gallery')) metrics.gallery += 1;
+                        if (tags.includes('Mobile')) metrics.mobile += 1;
+                    });
+                });
+
+                metrics.tagList = Array.from(metrics.tagCounts.keys()).sort((a, b) => a.localeCompare(b));
+                return metrics;
+            }
+            
+            createPolytopBackgrounds() {
+                const container = document.getElementById('polytopBackgrounds');
+
+                if (!this.polytopThemes.length) {
+                    console.warn('⚠️ No polytopal themes defined for gallery dataset.');
+                    return;
+                }
+
+                console.log('🧭 Evaluating rendering capabilities...');
+                console.log('  - User Agent:', navigator.userAgent);
+                console.log('  - Platform:', navigator.platform);
+                console.log('  - Reduced motion:', this.reducedMotion);
+
+                this.webglAvailable = !this.reducedMotion && this.detectWebGL();
+
+                if (this.webglAvailable) {
+                    console.log('🚀 WebGL background mode enabled.');
+                } else {
+                    console.log('🎨 CSS-only background mode enabled (WebGL unavailable or disabled).');
+                }
+
+                this.polytopThemes.forEach((theme, index) => {
+                    const backgroundDiv = document.createElement('div');
+                    backgroundDiv.className = 'polytopal-background';
+                    backgroundDiv.id = `polytop-${index}`;
+
+                    if (!this.webglAvailable) {
+                        backgroundDiv.classList.add('css-only');
+                    }
+
+                    if (this.webglAvailable) {
+                        // Try WebGL first
+                        const canvas = document.createElement('canvas');
+                        canvas.className = 'polytopal-canvas';
+                        canvas.id = `polytop-canvas-${index}`;
+
+                        // FORCE proper canvas dimensions
+                        canvas.width = window.innerWidth || 1920;
+                        canvas.height = window.innerHeight || 1080;
+                        canvas.style.width = '100%';
+                        canvas.style.height = '100%';
+                        canvas.style.display = 'block';
+                        
+                        backgroundDiv.appendChild(canvas);
+                        
+                        console.log(`🎯 Canvas ${index} created: ${canvas.width}x${canvas.height}`);
+
+                        // Initialize visualizer array slot
+                        this.polytopVisualizers[index] = null;
+
+                        // Create polytopal visualizer after canvas is ready
+                        setTimeout(() => {
+                            try {
+                                const visualizer = new PolytopBackgroundVisualizer(canvas, theme, index);
+                                this.polytopVisualizers[index] = visualizer;
+                                console.log(`✅ WebGL Visualizer ${index}: ${theme.name}`);
+                            } catch (error) {
+                                console.log(`🎨 WebGL failed for ${index}, using CSS fallback: ${theme.name}`);
+                                this.polytopVisualizers[index] = null;
+                                backgroundDiv.classList.add('css-only');
+                            }
+                        }, index * 100);
+                    } else {
+                        // Use CSS-only mode
+                        this.polytopVisualizers[index] = null;
+                        console.log(`🎨 CSS-Only Background ${index}: ${theme.name}`);
+                    }
+                    
+                    container.appendChild(backgroundDiv);
+                });
+                
+                // Activate first background immediately
+                setTimeout(() => {
+                    this.updatePolytopVisibility();
+                }, 500);
+            }
+
+            detectWebGL() {
+                try {
+                    const canvas = document.createElement('canvas');
+                    const options = { antialias: true, alpha: true, failIfMajorPerformanceCaveat: true };
+                    const gl = canvas.getContext('webgl', options) || canvas.getContext('experimental-webgl', options);
+
+                    if (gl) {
+                        const loseContext = gl.getExtension && gl.getExtension('WEBGL_lose_context');
+                        if (loseContext) {
+                            loseContext.loseContext();
+                        }
+                        return true;
+                    }
+                } catch (error) {
+                    console.warn('⚠️ WebGL capability check failed:', error);
+                }
+
+                return false;
+            }
+            
+            createNavigation() {
+                const navSections = document.getElementById('navSections');
+
+                if (!navSections) {
+                    return;
+                }
+
+                if (!this.polytopThemes.length) {
+                    return;
+                }
+
+                this.navSections = [];
+
+                this.polytopThemes.forEach((theme, index) => {
+                    const section = document.createElement('div');
+                    section.className = 'nav-section';
+                    const tagSummary = Array.from(this.sectionTagSets[index] || []).slice(0, 3);
+                    const tagMarkup = tagSummary.length
+                        ? `<div class="nav-section-tags">${tagSummary.join(' • ')}</div>`
+                        : '';
+                    section.innerHTML = `
+                        <div class="nav-section-name">Section ${index + 1}: ${theme.name}</div>
+                        <div class="nav-section-info">${theme.geometry} • density: ${theme.density} • 3 cards</div>
+                        ${tagMarkup}
+                    `;
+
+                    section.dataset.sectionIndex = index;
+                    section.addEventListener('click', () => {
+                        this.jumpToSection(index);
+                    });
+
+                    navSections.appendChild(section);
+                    this.navSections.push(section);
+                });
+
+                this.updateNavigationTagStates();
+            }
+
+            createControlDeck() {
+                const deck = document.getElementById('controlDeck');
+                const toggle = document.getElementById('controlDeckToggle');
+                const panel = document.getElementById('controlDeckPanel');
+
+                if (!deck || !toggle || !panel) {
+                    return;
+                }
+
+                this.controlDeck = { deck, toggle, panel };
+
+                this.setControlDeckOpen(deck.classList.contains('open'), { skipPersist: true });
+
+                toggle.addEventListener('click', () => {
+                    const nextState = !deck.classList.contains('open');
+                    this.setControlDeckOpen(nextState);
+                });
+
+                this.renderControlDeck();
+                this.setupSearchInterface();
+                this.setupShareInterface();
+                this.setupPreferenceControls();
+                this.setupShortcutOverlay();
+                this.applyInitialControlDeckState();
+            }
+
+            renderControlDeck() {
+                const titleEl = document.getElementById('controlDeckTitle');
+                if (titleEl) titleEl.textContent = this.navTitle;
+
+                const subtitleEl = document.getElementById('controlDeckSubtitle');
+                if (subtitleEl) subtitleEl.textContent = this.tagline;
+
+                const statusEl = document.getElementById('controlDeckStatus');
+                if (statusEl) statusEl.textContent = this.baseControlDeckStatus;
+
+                const summaryEl = document.getElementById('controlDeckSummary');
+                if (summaryEl) {
+                    summaryEl.textContent = this.summary || 'Dataset overview loaded with reactive polytopal metrics.';
+                }
+
+                const metricsEl = document.getElementById('controlDeckMetrics');
+                if (metricsEl) {
+                    const metricData = [
+                        { label: 'Sections', value: this.metrics.totalSections },
+                        { label: 'Entries', value: this.metrics.totalEntries },
+                        { label: 'WebGL', value: this.metrics.webgl },
+                        { label: 'CSS', value: this.metrics.css },
+                        { label: 'Gallery', value: this.metrics.gallery },
+                        { label: 'Unique Tags', value: this.metrics.tagCounts.size }
+                    ];
+
+                    metricsEl.innerHTML = metricData.map((metric) => `
+                        <div class="control-deck-metric">
+                            <div class="control-deck-metric-value">${metric.value}</div>
+                            <div class="control-deck-metric-label">${metric.label}</div>
+                        </div>
+                    `).join('');
+                }
+
+                const tagsEl = document.getElementById('controlDeckTags');
+                if (tagsEl) {
+                    tagsEl.innerHTML = '';
+                    this.renderTagChips(tagsEl);
+                }
+
+                const calloutsEl = document.getElementById('controlDeckCallouts');
+                if (calloutsEl) {
+                    if (this.callouts.length) {
+                        calloutsEl.innerHTML = this.callouts.map((callout) => `<div class="control-deck-callout">${callout}</div>`).join('');
+                    } else {
+                        calloutsEl.innerHTML = '<div class="control-deck-callout">No additional callouts supplied for this dataset.</div>';
+                    }
+                }
+
+                this.updateControlDeckSection();
+                this.updateShareControls();
+                this.updateTagChipStates();
+                this.updateTagFocusList();
+                this.updateSearchResults();
+                this.updateTagHighlights();
+            }
+
+            escapeHtml(value) {
+                if (value === null || value === undefined) {
+                    return '';
+                }
+
+                return String(value)
+                    .replace(/&/g, '&amp;')
+                    .replace(/</g, '&lt;')
+                    .replace(/>/g, '&gt;')
+                    .replace(/"/g, '&quot;')
+                    .replace(/'/g, '&#39;');
+            }
+
+            setupSearchInterface() {
+                const searchInput = document.getElementById('controlDeckSearchInput');
+                const clearButton = document.getElementById('controlDeckSearchClear');
+
+                if (!searchInput) {
+                    return;
+                }
+
+                searchInput.addEventListener('input', (event) => {
+                    this.handleSearchInput(event.target.value);
+                });
+
+                searchInput.addEventListener('keydown', (event) => {
+                    if (event.key === 'Escape') {
+                        if (this.activeSearchQuery) {
+                            event.preventDefault();
+                            this.clearSearch();
+                        } else {
+                            searchInput.blur();
+                        }
+                    }
+                });
+
+                if (clearButton) {
+                    clearButton.addEventListener('click', () => {
+                        this.clearSearch();
+                    });
+                    clearButton.disabled = true;
+                }
+            }
+
+            setupShareInterface() {
+                const shareContainer = document.getElementById('controlDeckShare');
+                if (!shareContainer) {
+                    return;
+                }
+
+                this.shareStatusEl = document.getElementById('controlDeckShareStatus') || null;
+
+                shareContainer.addEventListener('click', (event) => {
+                    const button = event.target.closest('.control-deck-share-button');
+                    if (!button) {
+                        return;
+                    }
+
+                    if (button.disabled || button.getAttribute('aria-disabled') === 'true') {
+                        return;
+                    }
+
+                    const target = button.dataset.shareTarget || 'section';
+                    this.handleShareAction(target, button);
+                });
+            }
+
+            setControlDeckOpen(isOpen, options = {}) {
+                if (!this.controlDeck) {
+                    return false;
+                }
+
+                const { deck, toggle, panel } = this.controlDeck;
+                const desiredState = Boolean(isOpen);
+
+                deck.classList.toggle('open', desiredState);
+                if (toggle) {
+                    toggle.setAttribute('aria-expanded', desiredState ? 'true' : 'false');
+                }
+                if (panel) {
+                    panel.setAttribute('aria-hidden', desiredState ? 'false' : 'true');
+                }
+
+                this.preferences.deckOpen = desiredState;
+
+                if (options.skipPersist) {
+                    return desiredState;
+                }
+
+                if (this.rememberViewEnabled) {
+                    this.persistViewState();
+                } else if (this.preferences.autoOpenDeck) {
+                    this.savePreferences({ deckOpen: desiredState }, { force: true });
+                } else {
+                    this.savePreferences({ deckOpen: desiredState });
+                }
+
+                return desiredState;
+            }
+
+            setupPreferenceControls() {
+                const rememberToggle = document.getElementById('controlDeckRememberToggle');
+                if (rememberToggle) {
+                    rememberToggle.checked = this.rememberViewEnabled;
+                    rememberToggle.setAttribute('aria-checked', this.rememberViewEnabled ? 'true' : 'false');
+                    rememberToggle.addEventListener('change', () => {
+                        const enabled = Boolean(rememberToggle.checked);
+                        rememberToggle.setAttribute('aria-checked', enabled ? 'true' : 'false');
+                        this.rememberViewEnabled = enabled;
+                        this.savePreferences({ rememberView: enabled }, { force: true });
+                        if (!enabled) {
+                            this.clearRememberedView();
+                        } else {
+                            this.persistViewState();
+                        }
+                    });
+                }
+
+                const autoOpenToggle = document.getElementById('controlDeckAutoOpenToggle');
+                if (autoOpenToggle) {
+                    const autoOpen = Boolean(this.preferences.autoOpenDeck);
+                    autoOpenToggle.checked = autoOpen;
+                    autoOpenToggle.setAttribute('aria-checked', autoOpen ? 'true' : 'false');
+                    autoOpenToggle.addEventListener('change', () => {
+                        const enabled = Boolean(autoOpenToggle.checked);
+                        autoOpenToggle.setAttribute('aria-checked', enabled ? 'true' : 'false');
+                        this.savePreferences({ autoOpenDeck: enabled }, { force: true });
+                        if (enabled && this.controlDeck && !this.controlDeck.deck.classList.contains('open')) {
+                            this.setControlDeckOpen(true);
+                        }
+                    });
+                }
+
+                const helpButton = document.getElementById('controlDeckHelpButton');
+                if (helpButton) {
+                    helpButton.addEventListener('click', () => {
+                        this.showShortcutOverlay();
+                    });
+                }
+            }
+
+            setupShortcutOverlay() {
+                const overlay = document.getElementById('shortcutOverlay');
+                if (!overlay) {
+                    return;
+                }
+
+                const panel = overlay.querySelector('.shortcut-overlay-panel');
+                const closeButton = document.getElementById('shortcutOverlayClose');
+                const backdrop = document.getElementById('shortcutOverlayBackdrop');
+
+                if (panel && !panel.hasAttribute('tabindex')) {
+                    panel.setAttribute('tabindex', '-1');
+                }
+
+                this.shortcutOverlay = {
+                    overlay,
+                    panel,
+                    closeButton,
+                    backdrop,
+                    focusables: []
+                };
+
+                const handleClose = () => {
+                    this.hideShortcutOverlay();
+                };
+
+                if (closeButton) {
+                    closeButton.addEventListener('click', handleClose);
+                }
+
+                if (backdrop) {
+                    backdrop.addEventListener('click', handleClose);
+                }
+
+                overlay.addEventListener('keydown', (event) => {
+                    if (event.key === 'Escape') {
+                        event.preventDefault();
+                        this.hideShortcutOverlay();
+                        return;
+                    }
+
+                    if (event.key === 'Tab' && this.shortcutOverlay && this.shortcutOverlay.focusables.length) {
+                        const focusables = this.shortcutOverlay.focusables;
+                        const first = focusables[0];
+                        const last = focusables[focusables.length - 1];
+                        const active = document.activeElement;
+
+                        if (event.shiftKey) {
+                            if (active === first || !focusables.includes(active)) {
+                                event.preventDefault();
+                                last.focus();
+                            }
+                        } else if (active === last || !focusables.includes(active)) {
+                            event.preventDefault();
+                            first.focus();
+                        }
+                    }
+                });
+            }
+
+            applyInitialControlDeckState() {
+                if (!this.controlDeck) {
+                    return;
+                }
+
+                this.restoringState = true;
+
+                try {
+                    if (this.initialDeckOpen) {
+                        this.setControlDeckOpen(true, { skipPersist: true });
+                    }
+
+                    if (typeof this.initialSearchValue === 'string' && this.initialSearchValue.trim()) {
+                        const searchInput = document.getElementById('controlDeckSearchInput');
+                        if (searchInput) {
+                            searchInput.value = this.initialSearchValue;
+                        }
+                        this.handleSearchInput(this.initialSearchValue);
+                    }
+                } finally {
+                    this.restoringState = false;
+                }
+
+                if (this.rememberViewEnabled) {
+                    this.persistViewState();
+                }
+            }
+
+            isShortcutOverlayVisible() {
+                return Boolean(this.shortcutOverlay && this.shortcutOverlay.overlay && this.shortcutOverlay.overlay.classList.contains('is-visible'));
+            }
+
+            showShortcutOverlay() {
+                if (!this.shortcutOverlay || !this.shortcutOverlay.overlay) {
+                    return;
+                }
+
+                const { overlay, panel, closeButton } = this.shortcutOverlay;
+                overlay.classList.add('is-visible');
+                overlay.setAttribute('aria-hidden', 'false');
+                document.body.classList.add('shortcut-overlay-open');
+
+                const focusSelectors = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+                let focusables = [];
+                if (panel) {
+                    focusables = Array.from(panel.querySelectorAll(focusSelectors));
+                    focusables = focusables.filter((el) => {
+                        if (!el) return false;
+                        if (el.hasAttribute('disabled')) return false;
+                        if (el.getAttribute('aria-hidden') === 'true') return false;
+                        const rects = el.getClientRects();
+                        return rects && rects.length > 0;
+                    });
+                }
+
+                if (closeButton && !focusables.includes(closeButton)) {
+                    focusables.unshift(closeButton);
+                }
+
+                this.shortcutOverlay.focusables = focusables;
+                this.lastFocusedElement = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+
+                const focusTarget = focusables.length ? focusables[0] : panel;
+                if (focusTarget && typeof focusTarget.focus === 'function') {
+                    window.requestAnimationFrame(() => {
+                        focusTarget.focus();
+                    });
+                }
+            }
+
+            hideShortcutOverlay() {
+                if (!this.shortcutOverlay || !this.shortcutOverlay.overlay) {
+                    return;
+                }
+
+                const { overlay } = this.shortcutOverlay;
+                overlay.classList.remove('is-visible');
+                overlay.setAttribute('aria-hidden', 'true');
+                document.body.classList.remove('shortcut-overlay-open');
+                this.shortcutOverlay.focusables = [];
+
+                const restoreTarget = this.lastFocusedElement;
+                this.lastFocusedElement = null;
+
+                if (restoreTarget && typeof restoreTarget.focus === 'function') {
+                    window.requestAnimationFrame(() => {
+                        restoreTarget.focus();
+                    });
+                }
+            }
+
+            toggleShortcutOverlay(force) {
+                const shouldShow = typeof force === 'boolean' ? force : !this.isShortcutOverlayVisible();
+                if (shouldShow) {
+                    this.showShortcutOverlay();
+                } else {
+                    this.hideShortcutOverlay();
+                }
+            }
+
+            async handleShareAction(target, button) {
+                const sectionIndex = this.currentSection;
+                let waferIndex = null;
+
+                if (typeof target === 'string' && target.startsWith('wafer-')) {
+                    const parsed = parseInt(target.replace('wafer-', ''), 10);
+                    if (!Number.isNaN(parsed) && parsed >= 0 && parsed < 3) {
+                        waferIndex = parsed;
+                    }
+                }
+
+                if (waferIndex !== null) {
+                    this.setSpotlight(waferIndex, { replace: true });
+                } else {
+                    this.setSpotlight(null, { replace: true });
+                }
+
+                const shareUrl = this.buildShareUrl(sectionIndex, waferIndex);
+                const label = (button?.dataset?.shareLabel || button?.textContent || '').trim() || (waferIndex !== null
+                    ? `Card ${waferIndex + 1}`
+                    : `Section ${sectionIndex + 1}`);
+
+                try {
+                    await this.copyTextToClipboard(shareUrl);
+                    this.announceShareStatus(`Copied link for ${label}.`);
+                } catch (error) {
+                    console.warn('⚠️ Unable to copy share link.', error);
+                    this.announceShareStatus('Copy failed. Use browser share controls.', true);
+                }
+            }
+
+            updateShareControls() {
+                const shareContainer = document.getElementById('controlDeckShare');
+                if (!shareContainer) {
+                    return;
+                }
+
+                const sectionButton = shareContainer.querySelector('[data-share-target="section"]');
+                const theme = this.polytopThemes[this.currentSection];
+                const sectionLabel = theme?.name || `Section ${this.currentSection + 1}`;
+
+                if (sectionButton) {
+                    sectionButton.textContent = `Copy ${sectionLabel} Link`;
+                    sectionButton.dataset.shareLabel = `${sectionLabel} section`;
+                    sectionButton.disabled = false;
+                    sectionButton.setAttribute('aria-disabled', 'false');
+                }
+
+                const currentSet = this.contentSets[this.currentSection] || [];
+                for (let i = 0; i < 3; i++) {
+                    const button = shareContainer.querySelector(`[data-share-target="wafer-${i}"]`);
+                    if (!button) {
+                        continue;
+                    }
+
+                    const card = currentSet[i];
+                    if (card) {
+                        const cardTitle = card.title || card.name || `Card ${i + 1}`;
+                        button.textContent = `Copy ${cardTitle} Link`;
+                        button.dataset.shareLabel = `${cardTitle} card`;
+                        button.disabled = false;
+                        button.setAttribute('aria-disabled', 'false');
+                    } else {
+                        button.textContent = `Card ${i + 1} unavailable`;
+                        button.dataset.shareLabel = `Card ${i + 1}`;
+                        button.disabled = true;
+                        button.setAttribute('aria-disabled', 'true');
+                    }
+                }
+
+                if (this.shareStatusEl) {
+                    this.shareStatusEl.textContent = '';
+                    this.shareStatusEl.classList.remove('error');
+                }
+            }
+
+            buildShareUrl(sectionIndex, waferIndex) {
+                const safeSection = this.clampSectionIndex(sectionIndex);
+                const url = new URL(window.location.href);
+                const datasetKey = this.data?.key || document.body?.dataset?.galleryKey || null;
+
+                if (datasetKey) {
+                    url.searchParams.set('gallery', datasetKey);
+                }
+
+                const slug = this.sectionSlugs[safeSection];
+                if (slug) {
+                    url.searchParams.set('section', slug);
+                    url.hash = `section-${slug}`;
+                } else {
+                    url.searchParams.delete('section');
+                    if (url.hash) {
+                        url.hash = '';
+                    }
+                }
+
+                if (typeof waferIndex === 'number' && waferIndex >= 0 && waferIndex < 3) {
+                    url.searchParams.set('wafer', String(waferIndex + 1));
+                } else {
+                    url.searchParams.delete('wafer');
+                }
+
+                url.searchParams.delete('focus');
+                url.searchParams.delete('card');
+
+                return url.toString();
+            }
+
+            async copyTextToClipboard(value) {
+                if (navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
+                    await navigator.clipboard.writeText(value);
+                    return;
+                }
+
+                const textarea = document.createElement('textarea');
+                textarea.value = value;
+                textarea.setAttribute('readonly', '');
+                textarea.style.position = 'absolute';
+                textarea.style.left = '-9999px';
+                document.body.appendChild(textarea);
+
+                const selection = document.getSelection();
+                const savedRange = selection && selection.rangeCount ? selection.getRangeAt(0) : null;
+
+                textarea.select();
+                textarea.setSelectionRange(0, textarea.value.length);
+
+                const successful = document.execCommand ? document.execCommand('copy') : false;
+                document.body.removeChild(textarea);
+
+                if (savedRange && selection) {
+                    selection.removeAllRanges();
+                    selection.addRange(savedRange);
+                }
+
+                if (!successful) {
+                    throw new Error('Copy command was unsuccessful');
+                }
+            }
+
+            announceShareStatus(message, isError = false) {
+                if (!this.shareStatusEl) {
+                    return;
+                }
+
+                this.shareStatusEl.textContent = message;
+                this.shareStatusEl.classList.toggle('error', Boolean(isError));
+            }
+
+            handleSearchInput(value) {
+                const rawQuery = typeof value === 'string' ? value.trim() : '';
+                const normalized = rawQuery.toLowerCase();
+                const meetsThreshold = normalized.length >= 2;
+                this.activeSearchDisplayValue = meetsThreshold ? rawQuery : '';
+                this.activeSearchQuery = meetsThreshold ? normalized : '';
+
+                this.searchResults = [];
+                this.searchSectionMatches = new Set();
+                this.searchCardMatches = new Map();
+                this.searchResultKeySet = new Set();
+
+                if (this.activeSearchQuery) {
+                    this.searchResults = this.searchIndex.filter((entry) => entry.searchText.includes(this.activeSearchQuery));
+
+                    this.searchResults.forEach((entry) => {
+                        this.searchSectionMatches.add(entry.sectionIndex);
+                        if (!this.searchCardMatches.has(entry.sectionIndex)) {
+                            this.searchCardMatches.set(entry.sectionIndex, new Set());
+                        }
+                        this.searchCardMatches.get(entry.sectionIndex).add(entry.cardIndex);
+                        this.searchResultKeySet.add(`${entry.sectionIndex}:${entry.cardIndex}`);
+                    });
+                }
+
+                const clearButton = document.getElementById('controlDeckSearchClear');
+                if (clearButton) {
+                    clearButton.disabled = !this.activeSearchQuery;
+                }
+
+                this.updateSearchResults();
+                this.updateTagChipStates();
+                this.updateTagFocusList();
+                this.updateTagHighlights();
+                this.persistViewState();
+            }
+
+            clearSearch() {
+                if (!this.activeSearchQuery) {
+                    return;
+                }
+
+                const searchInput = document.getElementById('controlDeckSearchInput');
+                if (searchInput) {
+                    searchInput.value = '';
+                }
+
+                this.handleSearchInput('');
+            }
+
+            updateSearchResults() {
+                const resultsEl = document.getElementById('controlDeckSearchResults');
+                if (!resultsEl) {
+                    return;
+                }
+
+                resultsEl.classList.remove('empty');
+
+                if (!this.activeSearchQuery) {
+                    resultsEl.classList.add('empty');
+                    resultsEl.innerHTML = '<div class="control-deck-search-placeholder">Search across demos, tags, and sections.</div>';
+                    return;
+                }
+
+                const totalResults = this.searchResults.length;
+                const hasTagFilter = Boolean(this.activeTagFilter);
+                const filteredResults = hasTagFilter
+                    ? this.searchResults.filter((entry) => Array.isArray(entry.tags) && entry.tags.includes(this.activeTagFilter))
+                    : this.searchResults;
+
+                if (!totalResults) {
+                    resultsEl.classList.add('empty');
+                    const searchLabel = this.activeSearchDisplayValue || this.activeSearchQuery;
+                    const safeQuery = this.escapeHtml(searchLabel);
+                    resultsEl.innerHTML = `<div class="control-deck-search-placeholder">No matches for “${safeQuery}”. Try another keyword.</div>`;
+                    return;
+                }
+
+                if (!filteredResults.length) {
+                    resultsEl.classList.add('empty');
+                    const searchLabel = this.activeSearchDisplayValue || this.activeSearchQuery;
+                    const safeQuery = this.escapeHtml(searchLabel);
+                    const safeTag = this.escapeHtml(this.activeTagFilter);
+                    resultsEl.innerHTML = `<div class="control-deck-search-placeholder">No matches for “${safeQuery}” with the ${safeTag} tag filter.</div>`;
+                    return;
+                }
+
+                const maxResults = 6;
+                const rendered = filteredResults.slice(0, maxResults).map((entry) => {
+                    const sectionName = this.polytopThemes[entry.sectionIndex]?.name || `Section ${entry.sectionIndex + 1}`;
+                    const tags = entry.tags && entry.tags.length ? entry.tags.join(', ') : 'Untagged';
+                    const isCurrent = entry.sectionIndex === this.currentSection;
+                    const classNames = ['control-deck-search-item'];
+                    if (isCurrent) {
+                        classNames.push('current-section');
+                    }
+
+                    const safeUrl = this.escapeHtml(entry.url || '#');
+                    const safeTitle = this.escapeHtml(entry.title);
+                    const safeSection = this.escapeHtml(sectionName);
+                    const safeTags = this.escapeHtml(tags);
+
+                    return `
+                        <div class="${classNames.join(' ')}">
+                            <a href="${safeUrl}" target="_blank" rel="noopener noreferrer">${safeTitle}</a>
+                            <div class="control-deck-search-meta">Section ${entry.sectionIndex + 1} • ${safeSection}</div>
+                            <div class="control-deck-search-tags">${safeTags}</div>
+                        </div>
+                    `;
+                }).join('');
+
+                const remainder = filteredResults.length - maxResults;
+                const remainderNote = remainder > 0 ? `<div class="control-deck-search-more">+${remainder} more results</div>` : '';
+
+                resultsEl.innerHTML = rendered + remainderNote;
+            }
+
+            renderTagChips(container) {
+                if (!this.metrics.tagList.length) {
+                    const placeholder = document.createElement('span');
+                    placeholder.className = 'control-tag-chip reset';
+                    placeholder.textContent = 'No tags available';
+                    placeholder.setAttribute('aria-disabled', 'true');
+                    placeholder.tabIndex = -1;
+                    container.appendChild(placeholder);
+                    return;
+                }
+
+                this.metrics.tagList.forEach((tag) => {
+                    const chip = document.createElement('button');
+                    chip.type = 'button';
+                    chip.className = 'control-tag-chip';
+                    chip.dataset.tag = tag;
+                    const count = this.metrics.tagCounts.get(tag) || 0;
+                    chip.textContent = `${tag} (${count})`;
+                    chip.addEventListener('click', () => {
+                        this.toggleTagFilter(tag);
+                    });
+                    container.appendChild(chip);
+                });
+
+                const resetChip = document.createElement('button');
+                resetChip.type = 'button';
+                resetChip.className = 'control-tag-chip reset';
+                resetChip.dataset.reset = 'true';
+                resetChip.textContent = 'Reset';
+                resetChip.addEventListener('click', () => {
+                    this.clearTagFilter();
+                });
+                container.appendChild(resetChip);
+            }
+
+            toggleTagFilter(tag) {
+                if (this.activeTagFilter === tag) {
+                    this.activeTagFilter = null;
+                } else {
+                    this.activeTagFilter = tag;
+                }
+
+                this.updateTagChipStates();
+                this.updateTagFocusList();
+                this.updateSearchResults();
+                this.updateTagHighlights();
+                this.persistViewState();
+            }
+
+            clearTagFilter() {
+                if (!this.activeTagFilter) {
+                    return;
+                }
+
+                this.activeTagFilter = null;
+                this.updateTagChipStates();
+                this.updateTagFocusList();
+                this.updateSearchResults();
+                this.updateTagHighlights();
+                this.persistViewState();
+            }
+
+            updateTagChipStates() {
+                const tagsEl = document.getElementById('controlDeckTags');
+                if (!tagsEl) {
+                    return;
+                }
+
+                tagsEl.querySelectorAll('.control-tag-chip[data-tag]').forEach((chip) => {
+                    const isActive = this.activeTagFilter === chip.dataset.tag;
+                    chip.classList.toggle('active', isActive);
+                    chip.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+                });
+
+                const resetChip = tagsEl.querySelector('.control-tag-chip.reset');
+                if (resetChip) {
+                    resetChip.disabled = !this.activeTagFilter;
+                }
+
+                const statusEl = document.getElementById('controlDeckStatus');
+                if (statusEl) {
+                    if (this.activeSearchQuery) {
+                        const displayQuery = this.activeSearchDisplayValue || this.activeSearchQuery;
+                        statusEl.textContent = `Search • ${displayQuery}`;
+                    } else if (this.activeTagFilter) {
+                        statusEl.textContent = `Tag • ${this.activeTagFilter}`;
+                    } else {
+                        statusEl.textContent = this.baseControlDeckStatus;
+                    }
+                }
+            }
+
+            updateTagFocusList() {
+                const focusEl = document.getElementById('controlDeckFocus');
+                if (!focusEl) {
+                    return;
+                }
+
+                if (!this.activeTagFilter) {
+                    focusEl.classList.add('empty');
+                    if (this.activeSearchQuery) {
+                        focusEl.innerHTML = 'Search results are listed above. Select a tag to inspect coverage intersections.';
+                    } else {
+                        focusEl.innerHTML = 'Select a tag to inspect dataset coverage.';
+                    }
+                    return;
+                }
+
+                let entries = this.tagIndex.get(this.activeTagFilter) || [];
+                if (this.activeSearchQuery && this.searchResultKeySet.size) {
+                    entries = entries.filter((entry) => this.searchResultKeySet.has(`${entry.sectionIndex}:${entry.cardIndex}`));
+                }
+                if (!entries.length) {
+                    focusEl.classList.add('empty');
+                    const safeTagName = this.escapeHtml(this.activeTagFilter);
+                    focusEl.innerHTML = `No entries mapped to ${safeTagName}.`;
+                    return;
+                }
+
+                focusEl.classList.remove('empty');
+                const listItems = entries.map((entry) => {
+                    const sectionName = this.polytopThemes[entry.sectionIndex]?.name || `Section ${entry.sectionIndex + 1}`;
+                    const isCurrent = entry.sectionIndex === this.currentSection;
+                    const itemClass = isCurrent ? 'control-deck-focus-item current-section' : 'control-deck-focus-item';
+                    const safeUrl = this.escapeHtml(entry.url || '#');
+                    const safeTitle = this.escapeHtml(entry.title);
+                    const safeSection = this.escapeHtml(sectionName);
+                    return `
+                        <div class="${itemClass}">
+                            <a href="${safeUrl}" target="_blank" rel="noopener noreferrer">${safeTitle}</a>
+                            <div class="control-deck-focus-meta">Section ${entry.sectionIndex + 1} • ${safeSection}</div>
+                        </div>
+                    `;
+                }).join('');
+
+                const safeTag = this.escapeHtml(this.activeTagFilter);
+                focusEl.innerHTML = `
+                    <div class="control-deck-focus-title">${safeTag} — ${entries.length} items</div>
+                    <div class="control-deck-focus-list">${listItems}</div>
+                `;
+            }
+
+            updateTagHighlights() {
+                this.updateNavigationTagStates();
+                this.updateWaferHighlighting();
+            }
+
+            updateNavigationTagStates() {
+                const hasTagFilter = Boolean(this.activeTagFilter);
+                const hasSearch = Boolean(this.activeSearchQuery);
+                const hasFilter = hasTagFilter || hasSearch;
+                const sections = this.navSections.length ? this.navSections : Array.from(document.querySelectorAll('.nav-section'));
+
+                sections.forEach((section) => {
+                    const index = Number(section.dataset.sectionIndex || -1);
+                    const tags = this.sectionTagSets[index] || new Set();
+                    const tagMatch = !hasTagFilter || tags.has(this.activeTagFilter);
+                    const searchMatch = !hasSearch || this.searchSectionMatches.has(index);
+                    const finalMatch = hasFilter ? (tagMatch && searchMatch) : true;
+
+                    section.classList.toggle('tag-match', hasTagFilter && finalMatch);
+                    section.classList.toggle('tag-muted', hasTagFilter && hasFilter && !finalMatch);
+
+                    if (hasTagFilter) {
+                        section.setAttribute('data-tag-match', finalMatch ? 'true' : 'false');
+                    } else {
+                        section.removeAttribute('data-tag-match');
+                    }
+
+                    section.classList.toggle('search-match', hasSearch && finalMatch);
+                    section.classList.toggle('search-muted', hasSearch && hasFilter && !finalMatch);
+
+                    if (hasFilter) {
+                        section.setAttribute('data-filter-match', finalMatch ? 'true' : 'false');
+                    } else {
+                        section.removeAttribute('data-filter-match');
+                    }
+                });
+            }
+
+            updateControlDeckSection() {
+                const sectionValue = document.getElementById('controlDeckSectionValue');
+                if (!sectionValue) {
+                    return;
+                }
+
+                const theme = this.polytopThemes[this.currentSection];
+                if (theme) {
+                    sectionValue.textContent = `${this.currentSection + 1} · ${theme.name}`;
+                } else {
+                    sectionValue.textContent = `Section ${this.currentSection + 1}`;
+                }
+            }
+
+            updateWaferHighlighting() {
+                const hasTagFilter = Boolean(this.activeTagFilter);
+                const hasSearch = Boolean(this.activeSearchQuery);
+                const hasFilter = hasTagFilter || hasSearch;
+                const currentSet = this.contentSets[this.currentSection] || [];
+                const searchMatches = this.searchCardMatches.get(this.currentSection) || new Set();
+
+                for (let i = 0; i < 3; i++) {
+                    const wafer = document.getElementById(`crystal-wafer-${i}`);
+                    if (!wafer) {
+                        continue;
+                    }
+
+                    wafer.classList.remove('tag-match', 'tag-muted', 'search-match');
+
+                    if (!hasFilter) {
+                        continue;
+                    }
+
+                    const content = currentSet[i];
+                    const tagMatch = !hasTagFilter || (content && Array.isArray(content.tags) && content.tags.includes(this.activeTagFilter));
+                    const searchMatch = !hasSearch || searchMatches.has(i);
+                    const finalMatch = tagMatch && searchMatch;
+
+                    if (finalMatch) {
+                        if (hasTagFilter) {
+                            wafer.classList.add('tag-match');
+                        }
+                        if (hasSearch) {
+                            wafer.classList.add('search-match');
+                        }
+                    } else {
+                        wafer.classList.add('tag-muted');
+                    }
+                }
+            }
+
+            setSpotlight(index, options = {}) {
+                let resolvedIndex = typeof index === 'number' ? index : null;
+                const currentSet = this.contentSets[this.currentSection] || [];
+
+                if (resolvedIndex !== null) {
+                    if (resolvedIndex < 0 || resolvedIndex >= currentSet.length) {
+                        resolvedIndex = null;
+                    }
+                }
+
+                this.spotlightWaferIndex = resolvedIndex;
+
+                if (!options.deferRefresh) {
+                    this.refreshSpotlight();
+                }
+
+                const shouldUpdateHistory = options.updateHistory !== false;
+                const replace = options.replace !== undefined ? options.replace : true;
+
+                if (shouldUpdateHistory) {
+                    this.updateLocationState({
+                        sectionIndex: this.currentSection,
+                        waferIndex: resolvedIndex,
+                        replace
+                    });
+                }
+
+                this.persistViewState();
+            }
+
+            refreshSpotlight() {
+                for (let i = 0; i < 3; i++) {
+                    const wafer = document.getElementById(`crystal-wafer-${i}`);
+                    if (!wafer) {
+                        continue;
+                    }
+
+                    const isSpotlight = this.spotlightWaferIndex === i;
+                    wafer.classList.toggle('spotlight', isSpotlight);
+
+                    if (isSpotlight) {
+                        wafer.setAttribute('data-spotlight', 'true');
+                    } else {
+                        wafer.removeAttribute('data-spotlight');
+                    }
+                }
+            }
+
+            updateLocationState(options = {}) {
+                if (this.suppressHistoryUpdate) {
+                    return;
+                }
+
+                if (!window || !window.history || typeof window.history.replaceState !== 'function') {
+                    return;
+                }
+
+                try {
+                    const url = new URL(window.location.href);
+                    const datasetKey = this.data?.key || document.body?.dataset?.galleryKey || null;
+
+                    if (datasetKey) {
+                        url.searchParams.set('gallery', datasetKey);
+                    }
+
+                    const sectionIndex = typeof options.sectionIndex === 'number'
+                        ? this.clampSectionIndex(options.sectionIndex)
+                        : this.currentSection;
+
+                    const slug = this.sectionSlugs[sectionIndex];
+                    if (slug) {
+                        url.searchParams.set('section', slug);
+                        url.hash = `section-${slug}`;
+                    } else {
+                        url.searchParams.delete('section');
+                        if (url.hash) {
+                            url.hash = '';
+                        }
+                    }
+
+                    let waferIndex;
+                    if (Object.prototype.hasOwnProperty.call(options, 'waferIndex')) {
+                        waferIndex = typeof options.waferIndex === 'number' && options.waferIndex >= 0 && options.waferIndex < 3
+                            ? options.waferIndex
+                            : null;
+                    } else {
+                        waferIndex = typeof this.spotlightWaferIndex === 'number' && this.spotlightWaferIndex >= 0 && this.spotlightWaferIndex < 3
+                            ? this.spotlightWaferIndex
+                            : null;
+                    }
+
+                    if (waferIndex !== null) {
+                        url.searchParams.set('wafer', String(waferIndex + 1));
+                    } else {
+                        url.searchParams.delete('wafer');
+                    }
+
+                    url.searchParams.delete('focus');
+                    url.searchParams.delete('card');
+
+                    const state = {
+                        sectionSlug: slug || null,
+                        waferIndex: waferIndex !== null ? waferIndex : null
+                    };
+
+                    const shouldReplace = options.replace === true || !this.historyInitialized;
+                    const targetUrl = `${url.pathname}${url.search}${url.hash}`;
+
+                    if (shouldReplace) {
+                        window.history.replaceState(state, '', targetUrl);
+                        this.historyInitialized = true;
+                    } else if (typeof window.history.pushState === 'function') {
+                        window.history.pushState(state, '', targetUrl);
+                    }
+                } catch (error) {
+                    console.warn('⚠️ Unable to update history state for deep link.', error);
+                }
+            }
+
+            handlePopState(event) {
+                const state = event && event.state ? event.state : {};
+                let targetSection = null;
+                let waferIndex = null;
+
+                if (state.sectionSlug && this.sectionSlugMap && this.sectionSlugMap.has(state.sectionSlug)) {
+                    targetSection = this.sectionSlugMap.get(state.sectionSlug);
+                }
+
+                if (typeof state.waferIndex === 'number') {
+                    waferIndex = state.waferIndex;
+                }
+
+                if (targetSection === null || waferIndex === null) {
+                    const parsed = this.parseLocationForTarget();
+                    if (targetSection === null) {
+                        targetSection = parsed.sectionIndex;
+                    }
+                    if (waferIndex === null) {
+                        waferIndex = parsed.waferIndex;
+                    }
+                }
+
+                const sectionIsValid = typeof targetSection === 'number' && !Number.isNaN(targetSection);
+                const waferIsValid = typeof waferIndex === 'number' && waferIndex >= 0 && waferIndex < 3;
+
+                if (sectionIsValid && targetSection !== this.currentSection) {
+                    this.suppressHistoryUpdate = true;
+                    this.jumpToSection(targetSection);
+
+                    setTimeout(() => {
+                        this.suppressHistoryUpdate = false;
+                        if (waferIsValid) {
+                            this.setSpotlight(waferIndex, { updateHistory: false, replace: true });
+                        } else {
+                            this.setSpotlight(null, { updateHistory: false, replace: true });
+                        }
+                    }, 1100);
+                } else {
+                    if (waferIsValid) {
+                        this.setSpotlight(waferIndex, { updateHistory: false, replace: true });
+                    } else {
+                        this.setSpotlight(null, { updateHistory: false, replace: true });
+                    }
+                }
+            }
+
+            setupInteractions() {
+                // Navigation toggle
+                const navToggle = document.getElementById('navToggle');
+                const navContainer = document.getElementById('navContainer');
+
+                if (this.reducedMotion) {
+                    document.body.classList.add('reduced-motion');
+                }
+
+                navToggle.addEventListener('click', () => {
+                    navToggle.classList.toggle('open');
+                    navContainer.classList.toggle('open');
+                });
+
+                // Close nav when clicking outside
+                document.addEventListener('click', (e) => {
+                    if (!navContainer.contains(e.target) && !navToggle.contains(e.target)) {
+                        navToggle.classList.remove('open');
+                        navContainer.classList.remove('open');
+                    }
+                });
+                
+                // Mouse tracking for reactive effects
+                if (!this.reducedMotion) {
+                    document.addEventListener('mousemove', (e) => {
+                        this.mouseX = e.clientX / window.innerWidth;
+                        this.mouseY = 1.0 - (e.clientY / window.innerHeight);
+                        this.mouseIntensity = Math.min(1.0, Math.sqrt(e.movementX*e.movementX + e.movementY*e.movementY) / 50);
+
+                        // Update all visualizers
+                        this.polytopVisualizers.forEach(viz => {
+                            if (viz) viz.updateInteraction(this.mouseX, this.mouseY, this.mouseIntensity);
+                        });
+                    });
+                }
+
+                // Scroll physics
+                this.setupScrollPhysics();
+
+                // Click reactions
+                this.setupClickReactions();
+
+                // Keyboard shortcuts
+                this.setupKeyboardShortcuts();
+
+                if (this.boundPopStateHandler) {
+                    window.addEventListener('popstate', this.boundPopStateHandler);
+                }
+
+                if (this.boundHashChangeHandler) {
+                    window.addEventListener('hashchange', this.boundHashChangeHandler);
+                }
+            }
+            
+            setupScrollPhysics() {
+                const isMobile = window.innerWidth <= 768;
+                const simplifiedScroll = isMobile || this.reducedMotion;
+
+                if (simplifiedScroll) {
+                    const snapType = this.reducedMotion ? 'y proximity' : 'y mandatory';
+                    const modeLabel = this.reducedMotion ? '♿ Reduced motion scroll mode enabled' : '📱 Mobile scroll snap enabled';
+                    console.log(modeLabel);
+                    document.body.style.overflowY = 'auto';
+                    document.body.style.scrollSnapType = snapType;
+
+                    // Simple touch-friendly transitions
+                    let scrollTimeout;
+                    window.addEventListener('scroll', () => {
+                        clearTimeout(scrollTimeout);
+                        scrollTimeout = setTimeout(() => {
+                            // Basic section detection for simplified mode
+                            const scrollableHeight = Math.max(1, document.body.scrollHeight - window.innerHeight);
+                            const scrollPercent = window.scrollY / scrollableHeight;
+                            const maxIndex = Math.max(0, this.polytopThemes.length - 1);
+                            const newSection = Math.round(scrollPercent * maxIndex);
+                            if (newSection !== this.currentSection && newSection >= 0 && newSection <= maxIndex) {
+                                this.currentSection = newSection;
+                                this.updatePolytopVisibility();
+                                this.updateUI();
+                            }
+                        }, 100);
+                    });
+
+                    return;
+                }
+                
+                // Desktop: Original momentum system
+                let momentumDecay;
+                
+                console.log('🌀 Desktop tactile scroll physics initialized - threshold:', this.momentumThreshold);
+                
+                window.addEventListener('wheel', (e) => {
+                    e.preventDefault();
+                    
+                    if (this.isTransitioning) return;
+                    
+                    // Build momentum - slower accumulation for proper threshold feel
+                    const delta = Math.abs(e.deltaY);
+                    this.scrollMomentum += delta * 0.25; // Reduced from 0.4 to build slower
+                    this.scrollMomentum = Math.min(this.scrollMomentum, 100);
+                    
+                    // Update scroll progress for visualizers
+                    const scrollProgress = this.scrollMomentum / 100;
+                    this.polytopVisualizers.forEach(viz => {
+                        if (viz) viz.updateScroll(scrollProgress);
+                    });
+                    
+                    // Update card momentum effects as it builds
+                    this.updateCardMomentumEffects();
+                    
+                    // Show momentum indicator
+                    this.showMomentumIndicator();
+                    
+                    // Clear previous decay
+                    clearTimeout(momentumDecay);
+                    
+                    // Debug tactile scroll behavior
+                    if (this.scrollMomentum > 15) {
+                        console.log(`⚡ Building momentum: ${this.scrollMomentum.toFixed(1)}/${this.momentumThreshold} - cards anticipating`);
+                    }
+                    
+                    // Check for transition threshold - only trigger at 25, not before
+                    if (this.scrollMomentum >= this.momentumThreshold) {
+                        console.log(`🚀 THRESHOLD REACHED! Triggering transition at ${this.scrollMomentum.toFixed(1)}`);
+                        this.triggerTransition(e.deltaY > 0 ? 1 : -1);
+                    } else {
+                        // Set momentum decay - longer delay to allow building
+                        momentumDecay = setTimeout(() => {
+                            this.decayMomentum();
+                        }, 200); // Increased from 150ms
+                    }
+                }, { passive: false });
+            }
+            
+            setupClickReactions() {
+                document.addEventListener('click', (e) => {
+                    // Site-wide reaction
+                    this.triggerSiteReaction(e.clientX, e.clientY);
+
+                    // Check if click was on a card
+                    const card = e.target.closest('.crystal-wafer');
+                    if (card) {
+                        card.classList.add('clicked');
+                        setTimeout(() => {
+                            card.classList.remove('clicked');
+                        }, 600);
+
+                        // Check if click was on preview
+                        const preview = e.target.closest('.wafer-preview');
+                        if (preview) {
+                            preview.classList.add('clicked');
+                            setTimeout(() => {
+                                preview.classList.remove('clicked');
+                            }, 400);
+                        }
+                    }
+                });
+            }
+
+            setupKeyboardShortcuts() {
+                document.addEventListener('keydown', (event) => {
+                    const overlayVisible = this.isShortcutOverlayVisible();
+                    const isQuestionKey = event.key === '?' || (event.key === '/' && event.shiftKey);
+
+                    if (overlayVisible) {
+                        if (event.key === 'Escape' || isQuestionKey) {
+                            event.preventDefault();
+                            this.toggleShortcutOverlay(false);
+                        }
+                        return;
+                    }
+
+                    const target = event.target;
+                    const isEditable = target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable);
+                    const hasModifier = event.altKey || event.ctrlKey || event.metaKey;
+
+                    if (isEditable && !hasModifier) {
+                        return;
+                    }
+
+                    switch (event.key) {
+                        case 'ArrowRight':
+                        case 'ArrowDown':
+                            event.preventDefault();
+                            this.triggerTransition(1);
+                            break;
+                        case 'ArrowLeft':
+                        case 'ArrowUp':
+                            event.preventDefault();
+                            this.triggerTransition(-1);
+                            break;
+                        case 'Home':
+                            event.preventDefault();
+                            this.jumpToSection(0);
+                            break;
+                        case 'End':
+                            event.preventDefault();
+                            this.jumpToSection(Math.max(0, this.polytopThemes.length - 1));
+                            break;
+                        case '[':
+                            if (!hasModifier) {
+                                event.preventDefault();
+                                this.triggerTransition(-1);
+                            }
+                            break;
+                        case ']':
+                            if (!hasModifier) {
+                                event.preventDefault();
+                                this.triggerTransition(1);
+                            }
+                            break;
+                        case '0':
+                            if (!hasModifier) {
+                                event.preventDefault();
+                                this.setSpotlight(null);
+                            }
+                            break;
+                        case '1':
+                        case '2':
+                        case '3':
+                            if (!hasModifier) {
+                                event.preventDefault();
+                                this.toggleSpotlightByKey(parseInt(event.key, 10) - 1);
+                            }
+                            break;
+                        case '/':
+                            if (!hasModifier) {
+                                event.preventDefault();
+                                this.openSearchFromShortcut();
+                            }
+                            break;
+                        case '?':
+                            event.preventDefault();
+                            this.toggleShortcutOverlay();
+                            break;
+                        case 'd':
+                        case 'D':
+                            if (event.altKey && event.shiftKey && !event.ctrlKey && !event.metaKey) {
+                                event.preventDefault();
+                                const deckOpen = Boolean(this.controlDeck && this.controlDeck.deck && this.controlDeck.deck.classList.contains('open'));
+                                this.setControlDeckOpen(!deckOpen);
+                            }
+                            break;
+                        default:
+                            break;
+                    }
+                });
+            }
+
+            toggleSpotlightByKey(index) {
+                if (typeof index !== 'number' || index < 0 || index > 2) {
+                    return;
+                }
+
+                if (this.spotlightWaferIndex === index) {
+                    this.setSpotlight(null);
+                } else {
+                    this.setSpotlight(index);
+                }
+            }
+
+            openSearchFromShortcut() {
+                const searchInput = document.getElementById('controlDeckSearchInput');
+                if (!this.controlDeck || !this.controlDeck.deck || !searchInput) {
+                    return;
+                }
+
+                if (!this.controlDeck.deck.classList.contains('open')) {
+                    this.setControlDeckOpen(true);
+                }
+
+                window.requestAnimationFrame(() => {
+                    searchInput.focus();
+                    searchInput.select();
+                });
+            }
+
+            triggerSiteReaction(x, y) {
+                const siteReaction = document.getElementById('siteReaction');
+                siteReaction.style.setProperty('--click-x', (x / window.innerWidth * 100) + '%');
+                siteReaction.style.setProperty('--click-y', (y / window.innerHeight * 100) + '%');
+                
+                // Reset animation
+                siteReaction.style.animation = 'none';
+                siteReaction.offsetHeight; // Trigger reflow
+                siteReaction.style.animation = 'siteReaction 0.8s ease-out';
+            }
+            
+            jumpToSection(sectionIndex) {
+                if (this.isTransitioning) return;
+                
+                console.log(`💎 Navigation Jump: ${this.currentSection} → ${sectionIndex}`);
+                
+                this.isTransitioning = true;
+                this.performTransition(sectionIndex);
+                
+                // Close navigation
+                document.getElementById('navToggle').classList.remove('open');
+                document.getElementById('navContainer').classList.remove('open');
+                
+                setTimeout(() => {
+                    this.isTransitioning = false;
+                }, 1000);
+            }
+            
+            triggerTransition(direction) {
+                if (this.isTransitioning) return;
+                
+                const newSection = this.currentSection + direction;
+                
+                // Boundary check with wraparound
+                const lastIndex = Math.max(0, this.polytopThemes.length - 1);
+                let targetSection;
+                if (newSection < 0) {
+                    targetSection = lastIndex; // Wrap to last section
+                } else if (newSection > lastIndex) {
+                    targetSection = 0; // Wrap to first section
+                } else {
+                    targetSection = newSection;
+                }
+                
+                console.log(`💎 Transition: ${this.currentSection} → ${targetSection} (momentum: ${this.scrollMomentum.toFixed(1)})`);
+                
+                this.isTransitioning = true;
+                this.scrollMomentum = 0;
+                this.hideMomentumIndicator();
+                
+                this.performTransition(targetSection);
+                
+                setTimeout(() => {
+                    this.isTransitioning = false;
+                }, 1000);
+            }
+            
+            performTransition(targetSection) {
+                this.currentSection = targetSection;
+                this.spotlightWaferIndex = null;
+
+                // Update polytopal background with mathematical grace
+                this.updatePolytopVisibility();
+
+                // Update navigation
+                this.updateNavigation();
+                
+                // Crystal breaking and reforming sequence
+                this.crystalBreakingSequence();
+                
+                // Update UI
+                setTimeout(() => {
+                    this.updateUI();
+                }, 200);
+            }
+            
+            updatePolytopVisibility() {
+                const backgrounds = document.querySelectorAll('.polytopal-background');
+                backgrounds.forEach((bg, index) => {
+                    bg.classList.toggle('active', index === this.currentSection);
+                    
+                    // Ensure visualizer exists and is rendering
+                    if (index === this.currentSection && this.polytopVisualizers[index]) {
+                        // Activate the current visualizer
+                        const themeName = this.polytopThemes[index]?.name || `Section ${index + 1}`;
+                        console.log(`🎯 Activating visualizer ${index}: ${themeName}`);
+                    }
+                });
+            }
+            
+            crystalBreakingSequence() {
+                const wafers = document.querySelectorAll('.crystal-wafer');
+                
+                // Clear any momentum effects before starting
+                wafers.forEach(wafer => {
+                    wafer.style.transform = '';
+                    wafer.style.filter = '';
+                    wafer.style.transition = '';
+                });
+                
+                // Phase 1: Breaking animation
+                wafers.forEach((wafer, index) => {
+                    setTimeout(() => {
+                        wafer.classList.add('breaking');
+                        
+                        // Remove breaking class and add reforming
+                        setTimeout(() => {
+                            wafer.classList.remove('breaking');
+                            wafer.classList.add('reforming');
+                            
+                            // Update content during reform
+                            setTimeout(() => {
+                                this.updateWaferContent(index);
+                            }, 200);
+                            
+                            // Remove reforming class and ensure clean state
+                            setTimeout(() => {
+                                wafer.classList.remove('reforming');
+                                // Ensure clean state after reforming
+                                wafer.style.transform = '';
+                                wafer.style.filter = '';
+                                wafer.style.transition = '';
+                            }, 1000);
+                            
+                        }, 800);
+                    }, index * 80);
+                });
+            }
+            
+            // Add momentum-responsive card effects
+            updateCardMomentumEffects() {
+                // Don't interfere during transitions
+                if (this.isTransitioning) return;
+                
+                const wafers = document.querySelectorAll('.crystal-wafer');
+                const momentumPercent = this.scrollMomentum / this.momentumThreshold;
+                
+                wafers.forEach((wafer, index) => {
+                    // Skip if card is in breaking/reforming state
+                    if (wafer.classList.contains('breaking') || wafer.classList.contains('reforming')) {
+                        return;
+                    }
+                    
+                    const stagger = index * 0.1;
+                    const effectIntensity = Math.max(0, momentumPercent - stagger);
+                    
+                    if (effectIntensity > 0) {
+                        // Cards start to anticipate transition
+                        const anticipationScale = 1 + (effectIntensity * 0.01); // Reduced intensity
+                        const anticipationBrightness = 1 + (effectIntensity * 0.1);
+                        
+                        wafer.style.transform = `scale(${anticipationScale})`;
+                        wafer.style.filter = `brightness(${anticipationBrightness})`;
+                        wafer.style.transition = 'all 0.1s ease-out';
+                    } else {
+                        // Reset to normal only if not in animation state
+                        wafer.style.transform = '';
+                        wafer.style.filter = '';
+                        wafer.style.transition = 'all 0.3s ease-out';
+                    }
+                });
+            }
+            
+            createCrystalWafers() {
+                const container = document.getElementById('crystalContainer');
+
+                // Clear any existing content
+                container.innerHTML = '';
+
+                console.log('🔧 Creating 3 crystal wafers for desktop display');
+
+                if (!this.contentSets.length) {
+                    console.warn('⚠️ No content sets defined for gallery dataset.');
+                }
+
+                // Desktop: Always create exactly 3 cards in a centered grid
+                container.style.display = 'grid';
+                container.style.gridTemplateColumns = 'repeat(3, 1fr)';
+                container.style.gridTemplateRows = '1fr';
+                container.style.justifyContent = 'center';
+                container.style.alignItems = 'center';
+                container.style.gap = '30px';
+                
+                for (let i = 0; i < 3; i++) {
+                    const wafer = this.createWaferElement(i);
+                    container.appendChild(wafer);
+                    console.log(`✅ Created crystal wafer ${i}`);
+                }
+                
+                console.log('💎 Crystal wafers created successfully');
+            }
+            
+            createWaferElement(index) {
+                const wafer = document.createElement('div');
+                wafer.className = 'crystal-wafer';
+                wafer.id = `crystal-wafer-${index}`;
+                
+                wafer.innerHTML = `
+                    <div class="wafer-title" id="title-${index}">Loading...</div>
+                    <div class="wafer-preview" id="preview-${index}">
+                        <div style="display: flex; align-items: center; justify-content: center; height: 100%; color: var(--crystal-teal); font-size: 1.0em;">
+                            ◆ Initializing polytopal matrix...
+                        </div>
+                    </div>
+                    <div class="wafer-info" id="info-${index}">
+                        <div class="info-title" id="info-title-${index}">4D Analysis</div>
+                        <div class="info-description" id="info-description-${index}">Scanning polytopal structure...</div>
+                        <div class="info-tags" id="info-tags-${index}">
+                            <!-- Tags will be populated dynamically -->
+                        </div>
+                    </div>
+                `;
+                
+                // Add hover effects for background visualizer slowdown
+                wafer.addEventListener('mouseenter', () => {
+                    this.slowDownVisualizers();
+                });
+                
+                wafer.addEventListener('mouseleave', () => {
+                    this.speedUpVisualizers();
+                });
+                
+                // Add click to navigate to source
+                wafer.addEventListener('click', (e) => {
+                    const currentSet = this.contentSets[this.currentSection];
+                    const content = currentSet[index];
+                    if (content && content.url) {
+                        // Open demo in new tab
+                        window.open(content.url, '_blank');
+                        console.log(`🎯 Opening demo: ${content.name} → ${content.url}`);
+                    }
+                });
+                
+                return wafer;
+            }
+            
+            updateWaferContent(waferIndex) {
+                const currentSet = this.contentSets[this.currentSection];
+                const content = currentSet[waferIndex];
+                
+                // Handle case where there are fewer than 3 items in a section
+                if (!content) {
+                    const wafer = document.getElementById(`crystal-wafer-${waferIndex}`);
+                    if (wafer) {
+                        wafer.style.display = 'none';
+                        console.log(`⚠️ Hiding wafer ${waferIndex} - no content available`);
+                    }
+                    return;
+                }
+                
+                const wafer = document.getElementById(`crystal-wafer-${waferIndex}`);
+                if (wafer) {
+                    wafer.style.display = 'flex';
+                    console.log(`✅ Showing wafer ${waferIndex}:`, content.title);
+                } else {
+                    console.error(`❌ Wafer element ${waferIndex} not found!`);
+                }
+                
+                // Update text content without destroying DOM structure
+                const titleEl = document.getElementById(`title-${waferIndex}`);
+                const infoTitleEl = document.getElementById(`info-title-${waferIndex}`);
+                const infoDescEl = document.getElementById(`info-description-${waferIndex}`);
+                
+                if (titleEl) titleEl.textContent = content.title;
+                if (infoTitleEl) infoTitleEl.textContent = content.title;
+                if (infoDescEl) infoDescEl.textContent = content.description;
+                
+                // Update tags
+                const tagsContainer = document.getElementById(`info-tags-${waferIndex}`);
+                if (tagsContainer) {
+                    tagsContainer.innerHTML = content.tags.map(tag => 
+                        `<span class="info-tag">${tag}</span>`
+                    ).join('');
+                }
+                
+                // Auto-load preview
+                this.autoLoadPreview(waferIndex, content);
+            }
+            
+            updateContent() {
+                const currentSet = this.contentSets[this.currentSection];
+                
+                console.log(`🔄 Updating content for section ${this.currentSection}:`, currentSet);
+                
+                for (let i = 0; i < 3; i++) {
+                    this.updateWaferContent(i);
+                    console.log(`✅ Updated wafer ${i} content`);
+                }
+
+                this.updateTagHighlights();
+
+                console.log('💎 All wafers updated with current section content');
+            }
+            
+            autoLoadPreview(waferIndex, content) {
+                const preview = document.getElementById(`preview-${waferIndex}`);
+                
+                if (content.isHeavy) {
+                    preview.innerHTML = `
+                        <div style="padding: 20px; text-align: center;">
+                            <div style="color: var(--crystal-teal); margin-bottom: 15px; font-size: 1.1em;">${this.heavyPreview.label}</div>
+                            <div style="font-size: 0.8em; line-height: 1.6; color: var(--crystal-teal);">
+                                ${(this.heavyPreview.description || []).map(line => `${line}<br>`).join('')}
+                                <button onclick="window.open('${content.url}', '_blank')"
+                                        style="margin-top: 10px; padding: 8px 16px; background: var(--silicon-green);
+                                               border: 2px solid var(--crystal-teal); color: var(--crystal-teal);
+                                               border-radius: 6px; cursor: pointer; font-weight: bold; font-size: 0.8em;">
+                                    ${this.heavyPreview.button}
+                                </button>
+                            </div>
+                        </div>
+                    `;
+                } else {
+                    // Auto-load with staggered entrance
+                    setTimeout(() => {
+                        preview.innerHTML = `
+                            <iframe src="${content.url}" 
+                                    width="100%" 
+                                    height="100%" 
+                                    frameborder="0"
+                                    loading="lazy"
+                                    style="opacity: 0; transition: opacity 0.6s ease;">
+                            </iframe>
+                        `;
+                        
+                        const iframe = preview.querySelector('iframe');
+                        iframe.onload = () => {
+                            iframe.style.opacity = '1';
+                        };
+                    }, waferIndex * 150 + 300);
+                }
+            }
+            
+            updateNavigation() {
+                const navSections = document.querySelectorAll('.nav-section');
+                navSections.forEach((section, index) => {
+                    section.classList.toggle('active', index === this.currentSection);
+                });
+
+                this.updateNavigationTagStates();
+            }
+            
+            showMomentumIndicator() {
+                const indicator = document.getElementById('momentumIndicator');
+                const fill = document.getElementById('momentumFill');
+                
+                indicator.classList.add('active');
+                fill.style.width = `${this.scrollMomentum}%`;
+            }
+            
+            hideMomentumIndicator() {
+                const indicator = document.getElementById('momentumIndicator');
+                indicator.classList.remove('active');
+            }
+            
+            decayMomentum() {
+                const decayInterval = setInterval(() => {
+                    this.scrollMomentum -= 2; // Slower decay for better feel
+                    
+                    if (this.scrollMomentum <= 0) {
+                        this.scrollMomentum = 0;
+                        this.hideMomentumIndicator();
+                        clearInterval(decayInterval);
+                        
+                        // Reset scroll progress
+                        this.polytopVisualizers.forEach(viz => {
+                            if (viz) viz.updateScroll(0);
+                        });
+                        
+                        // Reset card effects
+                        this.updateCardMomentumEffects();
+                    } else {
+                        this.showMomentumIndicator();
+                        
+                        // Update scroll progress and card effects during decay
+                        const scrollProgress = this.scrollMomentum / 100;
+                        this.polytopVisualizers.forEach(viz => {
+                            if (viz) viz.updateScroll(scrollProgress);
+                        });
+                        this.updateCardMomentumEffects();
+                    }
+                }, 60); // Slightly slower decay rate
+            }
+            
+            updateUI() {
+                const theme = this.polytopThemes[this.currentSection];
+
+                // Update section info
+                const titleEl = document.getElementById('sectionTitle');
+                if (titleEl) titleEl.textContent = theme?.name || this.navTitle;
+                const subtitleEl = document.getElementById('sectionSubtitle');
+                if (subtitleEl) subtitleEl.textContent = this.subtitle;
+
+                this.updateControlDeckSection();
+                this.updateShareControls();
+                this.updateTagHighlights();
+                this.updateTagFocusList();
+                this.updateSearchResults();
+                this.refreshSpotlight();
+                this.updateLocationState();
+                this.persistViewState();
+            }
+            
+            slowDownVisualizers() {
+                if (this.reducedMotion || !this.webglAvailable) {
+                    return;
+                }
+
+                // Slow down all background visualizers
+                const backgrounds = document.querySelectorAll('.polytopal-background');
+                backgrounds.forEach(bg => {
+                    bg.classList.add('slowed');
+                });
+                
+                // Reduce visualizer speed
+                this.polytopVisualizers.forEach(viz => {
+                    if (viz) viz.setTimeScale(0.3);
+                });
+                
+                console.log('🐌 Visualizers slowed down for focus mode');
+            }
+
+            speedUpVisualizers() {
+                if (this.reducedMotion || !this.webglAvailable) {
+                    return;
+                }
+
+                // Return visualizers to normal speed
+                const backgrounds = document.querySelectorAll('.polytopal-background');
+                backgrounds.forEach(bg => {
+                    bg.classList.remove('slowed');
+                });
+
+                // Reset visualizer speed
+                this.polytopVisualizers.forEach(viz => {
+                    if (viz) viz.setTimeScale(1.0);
+                });
+
+                console.log('⚡ Visualizers returned to normal speed');
+            }
+
+            handleMotionPreferenceChange() {
+                const reduced = this.reducedMotion;
+                document.body.classList.toggle('reduced-motion', reduced);
+
+                if (reduced) {
+                    this.stopRenderLoop();
+                    console.log('♿ Reduced motion activated - render loop halted.');
+                } else {
+                    if (!this.webglAvailable) {
+                        console.log('ℹ️ Motion restored but WebGL visualizers were not created in this session. Reload to enable them.');
+                        return;
+                    }
+
+                    if (!this.renderLoopId) {
+                        this.startRenderLoop();
+                    }
+                }
+            }
+
+            startRenderLoop() {
+                if (this.reducedMotion || !this.webglAvailable) {
+                    console.log('🎬 Render loop skipped (reduced motion or CSS mode active).');
+                    return;
+                }
+
+                if (this.renderLoopId) {
+                    return;
+                }
+
+                const render = () => {
+                    this.polytopVisualizers.forEach((viz, index) => {
+                        if (viz && viz.gl && !viz.gl.isContextLost()) {
+                            try {
+                                viz.render();
+                            } catch (error) {
+                                console.warn(`⚠️ Visualizer ${index} render error:`, error);
+                                // Don't break the entire render loop for one failed visualizer
+                            }
+                        }
+                    });
+                    this.renderLoopId = window.requestAnimationFrame(render);
+                };
+
+                this.renderLoopId = window.requestAnimationFrame(render);
+                console.log('🎬 4D polytopal render loop started');
+            }
+
+            stopRenderLoop() {
+                if (this.renderLoopId) {
+                    cancelAnimationFrame(this.renderLoopId);
+                    this.renderLoopId = null;
+                    console.log('⏹ Render loop stopped.');
+                }
+            }
+        }
+
+        window.VisualCodexGallery = VisualCodexGallery;
+})();


### PR DESCRIPTION
## Summary
- add session preference toggles and an in-gallery shortcut guide overlay to both gallery shells
- persist dataset selection and view state, including deck visibility, search, tags, and spotlights, via new storage helpers
- wire up keyboard navigation shortcuts, overlay focus handling, and supporting styles/documentation updates

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e565b0bf888329a5617591165dfe72